### PR TITLE
ci(release): automate buildkit docker image releases

### DIFF
--- a/.github/changelog/release-changelog-builder.json
+++ b/.github/changelog/release-changelog-builder.json
@@ -1,0 +1,90 @@
+{
+  "template": "# Release #{{TO_TAG}}\n\n#{{CHANGELOG}}\n\n<details>\n<summary>Other changes</summary>\n\n#{{UNCATEGORIZED}}\n</details>",
+  "empty_template": "# Release #{{TO_TAG}}\n\nNo user-facing changes were detected.",
+  "commit_template": "- #{{TITLE}} by @#{{AUTHOR}} (#{{MERGE_SHA}})",
+  "categories": [
+    {
+      "title": "## Breaking Changes",
+      "labels": ["breaking", "boom", "💥"]
+    },
+    {
+      "title": "## Features",
+      "labels": ["feat", "feature", "sparkles", "✨"]
+    },
+    {
+      "title": "## Fixes",
+      "labels": ["fix", "bug", "bugfix", "🐛"]
+    },
+    {
+      "title": "## Reverts",
+      "labels": ["revert", "rewind", "↩️"]
+    },
+    {
+      "title": "## Performance",
+      "labels": ["perf", "zap", "⚡"]
+    },
+    {
+      "title": "## Refactoring",
+      "labels": ["refactor", "recycle", "♻️"]
+    },
+    {
+      "title": "## Documentation",
+      "labels": ["docs", "doc", "memo", "📝"]
+    },
+    {
+      "title": "## Tests",
+      "labels": ["test", "tests", "white_check_mark", "test_tube", "🧪"]
+    },
+    {
+      "title": "## CI / Build",
+      "labels": ["ci", "build", "construction_worker", "bricks", "🤖"]
+    },
+    {
+      "title": "## Dependencies",
+      "labels": ["deps", "dependency", "dependencies", "package", "📦"]
+    },
+    {
+      "title": "## Chores",
+      "labels": ["chore", "style", "wrench", "broom", "🧹"]
+    },
+    {
+      "title": "## Security",
+      "labels": ["security", "lock", "🔒"]
+    }
+  ],
+  "label_extractor": [
+    {
+      "pattern": "^(.+)!:",
+      "on_property": "title",
+      "target": "breaking"
+    },
+    {
+      "pattern": "BREAKING CHANGE",
+      "on_property": "body",
+      "method": "match",
+      "target": "breaking"
+    },
+    {
+      "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\-.]+\\))?(!)?: .+",
+      "on_property": "title",
+      "target": "$1"
+    },
+    {
+      "pattern": "^:(boom|sparkles|bug|zap|recycle|memo|white_check_mark|test_tube|construction_worker|bricks|package|wrench|broom|lock|rewind): .+",
+      "on_property": "title",
+      "target": "$1"
+    },
+    {
+      "pattern": "^(💥|✨|🐛|⚡|♻️|📝|🧪|🤖|📦|🧹|🔒|↩️) .+",
+      "on_property": "title",
+      "target": "$1"
+    }
+  ],
+  "sort": {
+    "order": "ASC",
+    "on_property": "mergedAt"
+  },
+  "trim_values": true,
+  "max_tags_to_fetch": 200,
+  "max_back_track_time_days": 365
+}

--- a/.github/scripts/buildkit-build.sh
+++ b/.github/scripts/buildkit-build.sh
@@ -47,4 +47,5 @@ echo "Building ${IMAGE_NAME} from ${DOCKERFILE_PATH}"
 printf 'Tags:\n%s\n' "${IMAGE_TAGS}"
 printf 'Cache ref: %s\n' "${CACHE_REF}"
 
-buildctl-daemonless.sh "${buildctl_args[@]}"
+buildkit_runner="${BUILDKIT_RUNNER:-/usr/local/bin/buildctl-daemonless.sh}"
+"${buildkit_runner}" "${buildctl_args[@]}"

--- a/.github/scripts/buildkit-build.sh
+++ b/.github/scripts/buildkit-build.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${IMAGE_NAME:?IMAGE_NAME is required}"
+: "${IMAGE_TAGS:?IMAGE_TAGS is required}"
+: "${DOCKERFILE_PATH:?DOCKERFILE_PATH is required}"
+: "${CACHE_REF:?CACHE_REF is required}"
+
+CONTEXT_DIR="${CONTEXT_DIR:-.}"
+PUSH_IMAGE="${PUSH_IMAGE:-true}"
+OUTPUT_FLAGS="${OUTPUT_FLAGS:-oci-mediatypes=true,name-canonical=true,push=${PUSH_IMAGE}}"
+
+mapfile -t tag_lines < <(printf '%s\n' "${IMAGE_TAGS}" | sed '/^[[:space:]]*$/d')
+
+if [[ "${#tag_lines[@]}" -eq 0 ]]; then
+  echo "No image tags provided" >&2
+  exit 1
+fi
+
+image_refs=()
+for tag in "${tag_lines[@]}"; do
+  image_refs+=("${IMAGE_NAME}:${tag}")
+done
+
+image_names_csv="$(IFS=,; echo "${image_refs[*]}")"
+
+buildctl_args=(
+  build
+  --frontend=dockerfile.v0
+  --local "context=${CONTEXT_DIR}"
+  --local "dockerfile=${CONTEXT_DIR}"
+  --opt "filename=${DOCKERFILE_PATH}"
+  --import-cache "type=registry,ref=${CACHE_REF}"
+  --export-cache "type=registry,ref=${CACHE_REF},mode=max,image-manifest=true,oci-mediatypes=true"
+  --output "type=image,name=${image_names_csv},${OUTPUT_FLAGS}"
+)
+
+if [[ -n "${BUILD_ARGS:-}" ]]; then
+  while IFS= read -r build_arg; do
+    [[ -z "${build_arg}" ]] && continue
+    buildctl_args+=(--opt "build-arg:${build_arg}")
+  done <<< "${BUILD_ARGS}"
+fi
+
+echo "Building ${IMAGE_NAME} from ${DOCKERFILE_PATH}"
+printf 'Tags:\n%s\n' "${IMAGE_TAGS}"
+printf 'Cache ref: %s\n' "${CACHE_REF}"
+
+buildctl-daemonless.sh "${buildctl_args[@]}"

--- a/.github/scripts/buildkit-build.sh
+++ b/.github/scripts/buildkit-build.sh
@@ -27,6 +27,7 @@ image_names_csv="$(IFS=,; echo "${image_refs[*]}")"
 
 buildctl_args=(
   build
+  --addr "${BUILDKIT_ADDR:-unix:///tmp/buildkitd.sock}"
   --frontend=dockerfile.v0
   --local "context=${CONTEXT_DIR}"
   --local "dockerfile=${CONTEXT_DIR}"
@@ -47,5 +48,31 @@ echo "Building ${IMAGE_NAME} from ${DOCKERFILE_PATH}"
 printf 'Tags:\n%s\n' "${IMAGE_TAGS}"
 printf 'Cache ref: %s\n' "${CACHE_REF}"
 
-buildkit_runner="${BUILDKIT_RUNNER:-/usr/local/bin/buildctl-daemonless.sh}"
-"${buildkit_runner}" "${buildctl_args[@]}"
+buildkitd_bin="${BUILDKITD_BIN:-/usr/local/bin/buildkitd}"
+buildkit_addr="${BUILDKIT_ADDR:-unix:///tmp/buildkitd.sock}"
+buildkit_log="$(mktemp)"
+
+cleanup() {
+  if [[ -n "${buildkitd_pid:-}" ]] && kill -0 "${buildkitd_pid}" 2>/dev/null; then
+    kill "${buildkitd_pid}" 2>/dev/null || true
+    wait "${buildkitd_pid}" 2>/dev/null || true
+  fi
+  rm -f "${buildkit_log}"
+}
+
+trap cleanup EXIT
+
+"${buildkitd_bin}" --addr "${buildkit_addr}" >"${buildkit_log}" 2>&1 &
+buildkitd_pid=$!
+
+for _ in $(seq 1 30); do
+  if buildctl --addr "${buildkit_addr}" debug workers >/dev/null 2>&1; then
+    buildctl "${buildctl_args[@]}"
+    exit 0
+  fi
+  sleep 1
+done
+
+cat "${buildkit_log}" >&2
+echo "BuildKit daemon did not become ready" >&2
+exit 1

--- a/.github/scripts/buildkit-build.sh
+++ b/.github/scripts/buildkit-build.sh
@@ -26,8 +26,8 @@ done
 image_names_csv="$(IFS=,; echo "${image_refs[*]}")"
 
 buildctl_args=(
-  build
   --addr "${BUILDKIT_ADDR:-tcp://127.0.0.1:1234}"
+  build
   --frontend=dockerfile.v0
   --local "context=${CONTEXT_DIR}"
   --local "dockerfile=${CONTEXT_DIR}"

--- a/.github/scripts/buildkit-build.sh
+++ b/.github/scripts/buildkit-build.sh
@@ -27,7 +27,7 @@ image_names_csv="$(IFS=,; echo "${image_refs[*]}")"
 
 buildctl_args=(
   build
-  --addr "${BUILDKIT_ADDR:-unix:///tmp/buildkitd.sock}"
+  --addr "${BUILDKIT_ADDR:-tcp://127.0.0.1:1234}"
   --frontend=dockerfile.v0
   --local "context=${CONTEXT_DIR}"
   --local "dockerfile=${CONTEXT_DIR}"
@@ -49,8 +49,13 @@ printf 'Tags:\n%s\n' "${IMAGE_TAGS}"
 printf 'Cache ref: %s\n' "${CACHE_REF}"
 
 buildkitd_bin="${BUILDKITD_BIN:-/usr/local/bin/buildkitd}"
-buildkit_addr="${BUILDKIT_ADDR:-unix:///tmp/buildkitd.sock}"
+buildkit_addr="${BUILDKIT_ADDR:-tcp://127.0.0.1:1234}"
 buildkit_log="$(mktemp)"
+buildkitd_cmd=("${buildkitd_bin}" --addr "${buildkit_addr}")
+
+if [[ "$(id -u)" -ne 0 ]] && command -v sudo >/dev/null 2>&1; then
+  buildkitd_cmd=(sudo -E "${buildkitd_cmd[@]}")
+fi
 
 cleanup() {
   if [[ -n "${buildkitd_pid:-}" ]] && kill -0 "${buildkitd_pid}" 2>/dev/null; then
@@ -62,7 +67,7 @@ cleanup() {
 
 trap cleanup EXIT
 
-"${buildkitd_bin}" --addr "${buildkit_addr}" >"${buildkit_log}" 2>&1 &
+"${buildkitd_cmd[@]}" >"${buildkit_log}" 2>&1 &
 buildkitd_pid=$!
 
 for _ in $(seq 1 30); do

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,11 @@ jobs:
           curl -fsSL \
             "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" \
             -o /tmp/buildkit.tgz
-          sudo tar -C /usr/local/bin --strip-components=1 -xzf /tmp/buildkit.tgz
+          tmp_dir="$(mktemp -d)"
+          tar -C "${tmp_dir}" -xzf /tmp/buildkit.tgz
+          sudo install -m 0755 "${tmp_dir}/bin/buildctl" /usr/local/bin/buildctl
+          sudo install -m 0755 "${tmp_dir}/bin/buildkitd" /usr/local/bin/buildkitd
+          sudo install -m 0755 "${tmp_dir}/bin/buildctl-daemonless.sh" /usr/local/bin/buildctl-daemonless.sh
           buildctl --version
 
       - name: Log in to Docker Hub
@@ -190,7 +194,11 @@ jobs:
           curl -fsSL \
             "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" \
             -o /tmp/buildkit.tgz
-          sudo tar -C /usr/local/bin --strip-components=1 -xzf /tmp/buildkit.tgz
+          tmp_dir="$(mktemp -d)"
+          tar -C "${tmp_dir}" -xzf /tmp/buildkit.tgz
+          sudo install -m 0755 "${tmp_dir}/bin/buildctl" /usr/local/bin/buildctl
+          sudo install -m 0755 "${tmp_dir}/bin/buildkitd" /usr/local/bin/buildkitd
+          sudo install -m 0755 "${tmp_dir}/bin/buildctl-daemonless.sh" /usr/local/bin/buildctl-daemonless.sh
           buildctl --version
 
       - name: Log in to Docker Hub
@@ -259,7 +267,11 @@ jobs:
           curl -fsSL \
             "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" \
             -o /tmp/buildkit.tgz
-          sudo tar -C /usr/local/bin --strip-components=1 -xzf /tmp/buildkit.tgz
+          tmp_dir="$(mktemp -d)"
+          tar -C "${tmp_dir}" -xzf /tmp/buildkit.tgz
+          sudo install -m 0755 "${tmp_dir}/bin/buildctl" /usr/local/bin/buildctl
+          sudo install -m 0755 "${tmp_dir}/bin/buildkitd" /usr/local/bin/buildkitd
+          sudo install -m 0755 "${tmp_dir}/bin/buildctl-daemonless.sh" /usr/local/bin/buildctl-daemonless.sh
           buildctl --version
 
       - name: Log in to Docker Hub

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       release_version: ${{ steps.bump.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -117,14 +117,14 @@ jobs:
       contents: read
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up BuildKit
         run: |
           curl -fsSL \
             "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" \
             -o /tmp/buildkit.tgz
-          sudo tar -C /usr/local --strip-components=1 -xzf /tmp/buildkit.tgz
+          sudo tar -C /usr/local/bin --strip-components=1 -xzf /tmp/buildkit.tgz
           buildctl --version
 
       - name: Log in to Docker Hub
@@ -183,14 +183,14 @@ jobs:
         java-version: ['17', '21']
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up BuildKit
         run: |
           curl -fsSL \
             "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" \
             -o /tmp/buildkit.tgz
-          sudo tar -C /usr/local --strip-components=1 -xzf /tmp/buildkit.tgz
+          sudo tar -C /usr/local/bin --strip-components=1 -xzf /tmp/buildkit.tgz
           buildctl --version
 
       - name: Log in to Docker Hub
@@ -252,14 +252,14 @@ jobs:
           - gatling-debug
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up BuildKit
         run: |
           curl -fsSL \
             "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" \
             -o /tmp/buildkit.tgz
-          sudo tar -C /usr/local --strip-components=1 -xzf /tmp/buildkit.tgz
+          sudo tar -C /usr/local/bin --strip-components=1 -xzf /tmp/buildkit.tgz
           buildctl --version
 
       - name: Log in to Docker Hub

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,28 +1,131 @@
-name: Galaxio Docker Images Building
+name: Galaxio Docker Images Release
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main
-    tags:
-      - '*'
+  workflow_dispatch:
 
 env:
-  KANIKO_CACHE_ARGS: type=registry,ref=galaxioteam/base-cache:cache
+  BUILDKIT_VERSION: v0.30.0
+  BUILD_CONTEXT: .
+  CACHE_REPOSITORY: galaxioteam/buildkit-cache
+  GATLING_VERSION: 3.11.5
+  GATLING_SBT_VERSION: 4.18.1
+  SBT_VERSION: 1.11.3
+  PICATINNY_VERSION: 1.10.3
+  GALAXIO_CLI_VERSION: 0.6.1
 
 jobs:
-  base-build:
+  prepare-release:
+    name: Prepare Release
     runs-on: ubuntu-24.04
     permissions:
+      contents: write
+    outputs:
+      last_tag: ${{ steps.bump.outputs.last_tag }}
+      release_tag: ${{ steps.bump.outputs.tag }}
+      release_version: ${{ steps.bump.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute next version and create git tag
+        id: bump
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git fetch --tags --force --prune
+
+          LAST_TAG="$(git describe --tags --abbrev=0 --match 'v*' --first-parent 2>/dev/null || true)"
+          echo "last_tag=${LAST_TAG}" >> "${GITHUB_OUTPUT}"
+
+          RANGE="${LAST_TAG:+${LAST_TAG}..HEAD}"
+          COMMITS="$(git log --pretty=format:%s ${RANGE})"
+          BUMP="patch"
+
+          if printf '%s\n' "${COMMITS}" | grep -Eiq 'BREAKING CHANGE|!:'; then
+            BUMP="major"
+          elif printf '%s\n' "${COMMITS}" | grep -Eiq '^feat(\(.+\))?:'; then
+            BUMP="minor"
+          fi
+
+          if [[ -z "${LAST_TAG}" ]]; then
+            MAJOR=0
+            MINOR=0
+            PATCH=0
+          else
+            IFS='.' read -r MAJOR MINOR PATCH <<< "${LAST_TAG#v}"
+          fi
+
+          case "${BUMP}" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+
+          NEXT_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+
+          if git rev-parse -q --verify "refs/tags/${NEXT_TAG}" >/dev/null; then
+            TAG_COMMIT="$(git rev-list -n 1 "${NEXT_TAG}")"
+            HEAD_COMMIT="$(git rev-parse HEAD)"
+
+            if [[ "${TAG_COMMIT}" == "${HEAD_COMMIT}" ]]; then
+              :
+            else
+              while git rev-parse -q --verify "refs/tags/${NEXT_TAG}" >/dev/null; do
+                IFS='.' read -r MAJOR MINOR PATCH <<< "${NEXT_TAG#v}"
+                PATCH=$((PATCH + 1))
+                NEXT_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+              done
+            fi
+          fi
+
+          VERSION="${NEXT_TAG#v}"
+
+          echo "tag=${NEXT_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+
+          if ! git rev-parse -q --verify "refs/tags/${NEXT_TAG}" >/dev/null; then
+            git tag -a "${NEXT_TAG}" -m "Release ${NEXT_TAG}"
+            git push origin "${NEXT_TAG}"
+          fi
+
+  build-base:
+    name: Build base
+    runs-on: ubuntu-24.04
+    needs: prepare-release
+    permissions:
       contents: read
-      packages: write
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up BuildKit
+        run: |
+          curl -fsSL \
+            "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" \
+            -o /tmp/buildkit.tgz
+          sudo tar -C /usr/local --strip-components=1 -xzf /tmp/buildkit.tgz
+          buildctl --version
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -30,32 +133,65 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and Push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: |
-            galaxioteam/base:latest
-            galaxioteam/base:${{ github.ref_name }}
-          cache-from: ${{ env.KANIKO_CACHE_ARGS }}
-          cache-to: ${{ env.KANIKO_CACHE_ARGS }},mode=max
-  java-build:
+      - name: Prepare build metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release_tag="${{ needs.prepare-release.outputs.release_tag }}"
+          release_version="${{ needs.prepare-release.outputs.release_version }}"
+          image_name="galaxioteam/base"
+          dockerfile_path="Dockerfile"
+          cache_ref="${CACHE_REPOSITORY}:base"
+          image_tags=$'latest\n'"${release_version}"$'\n'"${release_tag}"
+          build_args=""
+
+          {
+            echo "image_name=${image_name}"
+            echo "dockerfile_path=${dockerfile_path}"
+            echo "cache_ref=${cache_ref}"
+            echo "image_tags<<EOF"
+            printf '%s\n' "${image_tags}"
+            echo "EOF"
+            echo "build_args<<EOF"
+            printf '%s\n' "${build_args}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Build and push image with BuildKit
+        env:
+          IMAGE_NAME: ${{ steps.meta.outputs.image_name }}
+          IMAGE_TAGS: ${{ steps.meta.outputs.image_tags }}
+          DOCKERFILE_PATH: ${{ steps.meta.outputs.dockerfile_path }}
+          CACHE_REF: ${{ steps.meta.outputs.cache_ref }}
+          BUILD_ARGS: ${{ steps.meta.outputs.build_args }}
+          CONTEXT_DIR: ${{ env.BUILD_CONTEXT }}
+        run: ./.github/scripts/buildkit-build.sh
+
+  build-java:
+    name: Build java ${{ matrix.java-version }}
+    runs-on: ubuntu-24.04
+    needs:
+      - prepare-release
+      - build-base
+    permissions:
+      contents: read
     strategy:
+      fail-fast: false
       matrix:
-        java-version: [ 17, 21 ]
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      packages: write
-    needs: base-build
+        java-version: ['17', '21']
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up BuildKit
+        run: |
+          curl -fsSL \
+            "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" \
+            -o /tmp/buildkit.tgz
+          sudo tar -C /usr/local --strip-components=1 -xzf /tmp/buildkit.tgz
+          buildctl --version
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -63,17 +199,195 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build Java ${{ matrix.java-version }} and Push Image to docker registry
-        uses: docker/build-push-action@v5
+      - name: Prepare build metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release_tag="${{ needs.prepare-release.outputs.release_tag }}"
+          release_version="${{ needs.prepare-release.outputs.release_version }}"
+          image_name="galaxioteam/base-jdk"
+          dockerfile_path="java.Dockerfile"
+          cache_ref="${CACHE_REPOSITORY}:base-jdk-${{ matrix.java-version }}"
+          image_tags="${{ matrix.java-version }}"$'\n'"${{ matrix.java-version }}-${release_version}"$'\n'"${{ matrix.java-version }}-${release_tag}"
+          build_args=$'BASE_VERSION='"${release_version}"$'\nJAVA_VERSION=${{ matrix.java-version }}'
+
+          {
+            echo "image_name=${image_name}"
+            echo "dockerfile_path=${dockerfile_path}"
+            echo "cache_ref=${cache_ref}"
+            echo "image_tags<<EOF"
+            printf '%s\n' "${image_tags}"
+            echo "EOF"
+            echo "build_args<<EOF"
+            printf '%s\n' "${build_args}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Build and push image with BuildKit
+        env:
+          IMAGE_NAME: ${{ steps.meta.outputs.image_name }}
+          IMAGE_TAGS: ${{ steps.meta.outputs.image_tags }}
+          DOCKERFILE_PATH: ${{ steps.meta.outputs.dockerfile_path }}
+          CACHE_REF: ${{ steps.meta.outputs.cache_ref }}
+          BUILD_ARGS: ${{ steps.meta.outputs.build_args }}
+          CONTEXT_DIR: ${{ env.BUILD_CONTEXT }}
+        run: ./.github/scripts/buildkit-build.sh
+
+  build-gatling-images:
+    name: Build ${{ matrix.target }}
+    runs-on: ubuntu-24.04
+    needs: prepare-release
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - gatling-sbt-builder
+          - gatling-maven-builder
+          - gatling-gradle-builder
+          - gatling-runtime
+          - gatling-debug
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up BuildKit
+        run: |
+          curl -fsSL \
+            "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" \
+            -o /tmp/buildkit.tgz
+          sudo tar -C /usr/local --strip-components=1 -xzf /tmp/buildkit.tgz
+          buildctl --version
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
         with:
-          context: .
-          file: ./java.Dockerfile
-          push: true
-          tags: |
-            galaxioteam/base-jdk:latest
-            galaxioteam/base-jdk:${{ github.ref_name }}
-          cache-from: ${{ env.KANIKO_CACHE_ARGS }}
-          cache-to: ${{ env.KANIKO_CACHE_ARGS }},mode=max
-          build-args: |
-            BASE_VERSION=${{ github.ref_name }}
-            JAVA_VERSION=${{ matrix.java-version }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Prepare build metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release_tag="${{ needs.prepare-release.outputs.release_tag }}"
+          release_version="${{ needs.prepare-release.outputs.release_version }}"
+
+          case "${{ matrix.target }}" in
+            gatling-sbt-builder)
+              image_name="galaxioteam/gatling-sbt-builder"
+              dockerfile_path="gatling-sbt-builder.Dockerfile"
+              cache_ref="${CACHE_REPOSITORY}:gatling-sbt-builder"
+              image_tags=$'latest\n'"${release_version}"$'\n'"${release_tag}"$'\n'"${GATLING_VERSION}"$'-sbt'
+              build_args=$'GATLING_VERSION='"${GATLING_VERSION}"$'\nGATLING_SBT_VERSION='"${GATLING_SBT_VERSION}"$'\nSBT_VERSION='"${SBT_VERSION}"$'\nPICATINNY_VERSION='"${PICATINNY_VERSION}"$'\nGALAXIO_CLI_VERSION='"${GALAXIO_CLI_VERSION}"
+              ;;
+            gatling-maven-builder)
+              image_name="galaxioteam/gatling-maven-builder"
+              dockerfile_path="gatling-maven-builder.Dockerfile"
+              cache_ref="${CACHE_REPOSITORY}:gatling-maven-builder"
+              image_tags=$'latest\n'"${release_version}"$'\n'"${release_tag}"$'\n'"${GATLING_VERSION}"$'-maven'
+              build_args=$'GATLING_VERSION='"${GATLING_VERSION}"
+              ;;
+            gatling-gradle-builder)
+              image_name="galaxioteam/gatling-gradle-builder"
+              dockerfile_path="gatling-gradle-builder.Dockerfile"
+              cache_ref="${CACHE_REPOSITORY}:gatling-gradle-builder"
+              image_tags=$'latest\n'"${release_version}"$'\n'"${release_tag}"$'\n'"${GATLING_VERSION}"$'-gradle'
+              build_args=$'GATLING_VERSION='"${GATLING_VERSION}"
+              ;;
+            gatling-runtime)
+              image_name="galaxioteam/gatling-runtime"
+              dockerfile_path="gatling-runtime.Dockerfile"
+              cache_ref="${CACHE_REPOSITORY}:gatling-runtime"
+              image_tags=$'latest\n'"${release_version}"$'\n'"${release_tag}"$'\n'"${GATLING_VERSION}"
+              build_args=$'GATLING_VERSION='"${GATLING_VERSION}"
+              ;;
+            gatling-debug)
+              image_name="galaxioteam/gatling-debug"
+              dockerfile_path="gatling-debug.Dockerfile"
+              cache_ref="${CACHE_REPOSITORY}:gatling-debug"
+              image_tags=$'latest\n'"${release_version}"$'\n'"${release_tag}"$'\n'"${GATLING_VERSION}"
+              build_args=$'GATLING_VERSION='"${GATLING_VERSION}"
+              ;;
+            *)
+              echo "Unknown target: ${{ matrix.target }}" >&2
+              exit 1
+              ;;
+          esac
+
+          {
+            echo "image_name=${image_name}"
+            echo "dockerfile_path=${dockerfile_path}"
+            echo "cache_ref=${cache_ref}"
+            echo "image_tags<<EOF"
+            printf '%s\n' "${image_tags}"
+            echo "EOF"
+            echo "build_args<<EOF"
+            printf '%s\n' "${build_args}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Build and push image with BuildKit
+        env:
+          IMAGE_NAME: ${{ steps.meta.outputs.image_name }}
+          IMAGE_TAGS: ${{ steps.meta.outputs.image_tags }}
+          DOCKERFILE_PATH: ${{ steps.meta.outputs.dockerfile_path }}
+          CACHE_REF: ${{ steps.meta.outputs.cache_ref }}
+          BUILD_ARGS: ${{ steps.meta.outputs.build_args }}
+          CONTEXT_DIR: ${{ env.BUILD_CONTEXT }}
+        run: ./.github/scripts/buildkit-build.sh
+
+  changelog:
+    name: Generate Changelog
+    runs-on: ubuntu-24.04
+    needs: prepare-release
+    permissions:
+      contents: read
+    outputs:
+      changelog: ${{ steps.changelog.outputs.changelog }}
+    steps:
+      - name: Generate changelog
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v6
+        with:
+          mode: COMMIT
+          fromTag: ${{ needs.prepare-release.outputs.last_tag }}
+          toTag: ${{ needs.prepare-release.outputs.release_tag }}
+          configuration: .github/changelog/release-changelog-builder.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-24.04
+    needs:
+      - prepare-release
+      - build-base
+      - build-java
+      - build-gatling-images
+      - changelog
+    permissions:
+      contents: write
+    steps:
+      - name: Create release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ needs.prepare-release.outputs.release_tag }}
+          body: |
+            ${{ needs.changelog.outputs.changelog }}
+
+            ## Docker images
+            - `galaxioteam/base:${{ needs.prepare-release.outputs.release_version }}`
+            - `galaxioteam/base-jdk:17-${{ needs.prepare-release.outputs.release_version }}`
+            - `galaxioteam/base-jdk:21-${{ needs.prepare-release.outputs.release_version }}`
+            - `galaxioteam/gatling-sbt-builder:${{ needs.prepare-release.outputs.release_version }}`
+            - `galaxioteam/gatling-maven-builder:${{ needs.prepare-release.outputs.release_version }}`
+            - `galaxioteam/gatling-gradle-builder:${{ needs.prepare-release.outputs.release_version }}`
+            - `galaxioteam/gatling-runtime:${{ needs.prepare-release.outputs.release_version }}`
+            - `galaxioteam/gatling-debug:${{ needs.prepare-release.outputs.release_version }}`
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,6 @@ jobs:
           tar -C "${tmp_dir}" -xzf /tmp/buildkit.tgz
           sudo install -m 0755 "${tmp_dir}/bin/buildctl" /usr/local/bin/buildctl
           sudo install -m 0755 "${tmp_dir}/bin/buildkitd" /usr/local/bin/buildkitd
-          sudo install -m 0755 "${tmp_dir}/bin/buildctl-daemonless.sh" /usr/local/bin/buildctl-daemonless.sh
           buildctl --version
 
       - name: Log in to Docker Hub
@@ -198,7 +197,6 @@ jobs:
           tar -C "${tmp_dir}" -xzf /tmp/buildkit.tgz
           sudo install -m 0755 "${tmp_dir}/bin/buildctl" /usr/local/bin/buildctl
           sudo install -m 0755 "${tmp_dir}/bin/buildkitd" /usr/local/bin/buildkitd
-          sudo install -m 0755 "${tmp_dir}/bin/buildctl-daemonless.sh" /usr/local/bin/buildctl-daemonless.sh
           buildctl --version
 
       - name: Log in to Docker Hub
@@ -271,7 +269,6 @@ jobs:
           tar -C "${tmp_dir}" -xzf /tmp/buildkit.tgz
           sudo install -m 0755 "${tmp_dir}/bin/buildctl" /usr/local/bin/buildctl
           sudo install -m 0755 "${tmp_dir}/bin/buildkitd" /usr/local/bin/buildkitd
-          sudo install -m 0755 "${tmp_dir}/bin/buildctl-daemonless.sh" /usr/local/bin/buildctl-daemonless.sh
           buildctl --version
 
       - name: Log in to Docker Hub

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -1,25 +1,38 @@
-name: Galaxio Docker Images Building
+name: Galaxio Docker Images Pull Request
 
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ '**' ]
+    branches:
+      - '**'
 
 env:
-  KANIKO_CACHE_ARGS: type=registry,ref=galaxioteam/base-cache:cache
+  BUILDKIT_VERSION: v0.30.0
+  BUILD_CONTEXT: .
+  CACHE_REPOSITORY: galaxioteam/buildkit-cache
+  GATLING_VERSION: 3.11.5
+  GATLING_SBT_VERSION: 4.18.1
+  SBT_VERSION: 1.11.3
+  PICATINNY_VERSION: 1.10.3
+  GALAXIO_CLI_VERSION: 0.6.1
 
 jobs:
-  base-build:
+  build-base:
+    name: Build base
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up BuildKit
+        run: |
+          curl -fsSL \
+            "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" \
+            -o /tmp/buildkit.tgz
+          sudo tar -C /usr/local --strip-components=1 -xzf /tmp/buildkit.tgz
+          buildctl --version
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -27,32 +40,62 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and Push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: |
-            galaxioteam/base:latest
-            galaxioteam/base:${{ github.sha }}
-          cache-from: ${{ env.KANIKO_CACHE_ARGS }}
-          cache-to: ${{ env.KANIKO_CACHE_ARGS }},mode=max
-  java-build:
+      - name: Prepare build metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          sha_tag="${GITHUB_SHA}"
+          image_name="galaxioteam/base"
+          dockerfile_path="Dockerfile"
+          cache_ref="${CACHE_REPOSITORY}:base-pr"
+          image_tags="${sha_tag}"
+          build_args=""
+
+          {
+            echo "image_name=${image_name}"
+            echo "dockerfile_path=${dockerfile_path}"
+            echo "cache_ref=${cache_ref}"
+            echo "image_tags<<EOF"
+            printf '%s\n' "${image_tags}"
+            echo "EOF"
+            echo "build_args<<EOF"
+            printf '%s\n' "${build_args}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Build and push image with BuildKit
+        env:
+          IMAGE_NAME: ${{ steps.meta.outputs.image_name }}
+          IMAGE_TAGS: ${{ steps.meta.outputs.image_tags }}
+          DOCKERFILE_PATH: ${{ steps.meta.outputs.dockerfile_path }}
+          CACHE_REF: ${{ steps.meta.outputs.cache_ref }}
+          BUILD_ARGS: ${{ steps.meta.outputs.build_args }}
+          CONTEXT_DIR: ${{ env.BUILD_CONTEXT }}
+        run: ./.github/scripts/buildkit-build.sh
+
+  build-java:
+    name: Build java ${{ matrix.java-version }}
+    runs-on: ubuntu-24.04
+    needs: build-base
+    permissions:
+      contents: read
     strategy:
+      fail-fast: false
       matrix:
-        java-version: [ 17, 21 ]
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      packages: write
-    needs: base-build
+        java-version: ['17', '21']
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up BuildKit
+        run: |
+          curl -fsSL \
+            "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" \
+            -o /tmp/buildkit.tgz
+          sudo tar -C /usr/local --strip-components=1 -xzf /tmp/buildkit.tgz
+          buildctl --version
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -60,17 +103,141 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build Java ${{ matrix.java-version }} and Push Image to docker registry
-        uses: docker/build-push-action@v5
+      - name: Prepare build metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          sha_tag="${GITHUB_SHA}"
+          image_name="galaxioteam/base-jdk"
+          dockerfile_path="java.Dockerfile"
+          cache_ref="${CACHE_REPOSITORY}:base-jdk-${{ matrix.java-version }}-pr"
+          image_tags="${{ matrix.java-version }}-${sha_tag}"
+          build_args=$'BASE_VERSION='"${sha_tag}"$'\nJAVA_VERSION=${{ matrix.java-version }}'
+
+          {
+            echo "image_name=${image_name}"
+            echo "dockerfile_path=${dockerfile_path}"
+            echo "cache_ref=${cache_ref}"
+            echo "image_tags<<EOF"
+            printf '%s\n' "${image_tags}"
+            echo "EOF"
+            echo "build_args<<EOF"
+            printf '%s\n' "${build_args}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Build and push image with BuildKit
+        env:
+          IMAGE_NAME: ${{ steps.meta.outputs.image_name }}
+          IMAGE_TAGS: ${{ steps.meta.outputs.image_tags }}
+          DOCKERFILE_PATH: ${{ steps.meta.outputs.dockerfile_path }}
+          CACHE_REF: ${{ steps.meta.outputs.cache_ref }}
+          BUILD_ARGS: ${{ steps.meta.outputs.build_args }}
+          CONTEXT_DIR: ${{ env.BUILD_CONTEXT }}
+        run: ./.github/scripts/buildkit-build.sh
+
+  build-gatling-images:
+    name: Build ${{ matrix.target }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - gatling-sbt-builder
+          - gatling-maven-builder
+          - gatling-gradle-builder
+          - gatling-runtime
+          - gatling-debug
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up BuildKit
+        run: |
+          curl -fsSL \
+            "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" \
+            -o /tmp/buildkit.tgz
+          sudo tar -C /usr/local --strip-components=1 -xzf /tmp/buildkit.tgz
+          buildctl --version
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
         with:
-          context: .
-          file: ./java.Dockerfile
-          push: true
-          tags: |
-            galaxioteam/base-jdk:latest
-            galaxioteam/base-jdk:${{ github.sha }}
-          cache-from: ${{ env.KANIKO_CACHE_ARGS }}
-          cache-to: ${{ env.KANIKO_CACHE_ARGS }},mode=max
-          build-args: |
-            BASE_VERSION=${{ github.sha }}
-            JAVA_VERSION=${{ matrix.java-version }}  
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Prepare build metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          sha_tag="${GITHUB_SHA}"
+
+          case "${{ matrix.target }}" in
+            gatling-sbt-builder)
+              image_name="galaxioteam/gatling-sbt-builder"
+              dockerfile_path="gatling-sbt-builder.Dockerfile"
+              cache_ref="${CACHE_REPOSITORY}:gatling-sbt-builder-pr"
+              image_tags="${sha_tag}"
+              build_args=$'GATLING_VERSION='"${GATLING_VERSION}"$'\nGATLING_SBT_VERSION='"${GATLING_SBT_VERSION}"$'\nSBT_VERSION='"${SBT_VERSION}"$'\nPICATINNY_VERSION='"${PICATINNY_VERSION}"$'\nGALAXIO_CLI_VERSION='"${GALAXIO_CLI_VERSION}"
+              ;;
+            gatling-maven-builder)
+              image_name="galaxioteam/gatling-maven-builder"
+              dockerfile_path="gatling-maven-builder.Dockerfile"
+              cache_ref="${CACHE_REPOSITORY}:gatling-maven-builder-pr"
+              image_tags="${sha_tag}"
+              build_args=$'GATLING_VERSION='"${GATLING_VERSION}"
+              ;;
+            gatling-gradle-builder)
+              image_name="galaxioteam/gatling-gradle-builder"
+              dockerfile_path="gatling-gradle-builder.Dockerfile"
+              cache_ref="${CACHE_REPOSITORY}:gatling-gradle-builder-pr"
+              image_tags="${sha_tag}"
+              build_args=$'GATLING_VERSION='"${GATLING_VERSION}"
+              ;;
+            gatling-runtime)
+              image_name="galaxioteam/gatling-runtime"
+              dockerfile_path="gatling-runtime.Dockerfile"
+              cache_ref="${CACHE_REPOSITORY}:gatling-runtime-pr"
+              image_tags="${sha_tag}"
+              build_args=$'GATLING_VERSION='"${GATLING_VERSION}"
+              ;;
+            gatling-debug)
+              image_name="galaxioteam/gatling-debug"
+              dockerfile_path="gatling-debug.Dockerfile"
+              cache_ref="${CACHE_REPOSITORY}:gatling-debug-pr"
+              image_tags="${sha_tag}"
+              build_args=$'GATLING_VERSION='"${GATLING_VERSION}"
+              ;;
+            *)
+              echo "Unknown target: ${{ matrix.target }}" >&2
+              exit 1
+              ;;
+          esac
+
+          {
+            echo "image_name=${image_name}"
+            echo "dockerfile_path=${dockerfile_path}"
+            echo "cache_ref=${cache_ref}"
+            echo "image_tags<<EOF"
+            printf '%s\n' "${image_tags}"
+            echo "EOF"
+            echo "build_args<<EOF"
+            printf '%s\n' "${build_args}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Build and push image with BuildKit
+        env:
+          IMAGE_NAME: ${{ steps.meta.outputs.image_name }}
+          IMAGE_TAGS: ${{ steps.meta.outputs.image_tags }}
+          DOCKERFILE_PATH: ${{ steps.meta.outputs.dockerfile_path }}
+          CACHE_REF: ${{ steps.meta.outputs.cache_ref }}
+          BUILD_ARGS: ${{ steps.meta.outputs.build_args }}
+          CONTEXT_DIR: ${{ env.BUILD_CONTEXT }}
+        run: ./.github/scripts/buildkit-build.sh

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -31,7 +31,11 @@ jobs:
           curl -fsSL \
             "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" \
             -o /tmp/buildkit.tgz
-          sudo tar -C /usr/local/bin --strip-components=1 -xzf /tmp/buildkit.tgz
+          tmp_dir="$(mktemp -d)"
+          tar -C "${tmp_dir}" -xzf /tmp/buildkit.tgz
+          sudo install -m 0755 "${tmp_dir}/bin/buildctl" /usr/local/bin/buildctl
+          sudo install -m 0755 "${tmp_dir}/bin/buildkitd" /usr/local/bin/buildkitd
+          sudo install -m 0755 "${tmp_dir}/bin/buildctl-daemonless.sh" /usr/local/bin/buildctl-daemonless.sh
           buildctl --version
 
       - name: Log in to Docker Hub
@@ -94,7 +98,11 @@ jobs:
           curl -fsSL \
             "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" \
             -o /tmp/buildkit.tgz
-          sudo tar -C /usr/local/bin --strip-components=1 -xzf /tmp/buildkit.tgz
+          tmp_dir="$(mktemp -d)"
+          tar -C "${tmp_dir}" -xzf /tmp/buildkit.tgz
+          sudo install -m 0755 "${tmp_dir}/bin/buildctl" /usr/local/bin/buildctl
+          sudo install -m 0755 "${tmp_dir}/bin/buildkitd" /usr/local/bin/buildkitd
+          sudo install -m 0755 "${tmp_dir}/bin/buildctl-daemonless.sh" /usr/local/bin/buildctl-daemonless.sh
           buildctl --version
 
       - name: Log in to Docker Hub
@@ -161,7 +169,11 @@ jobs:
           curl -fsSL \
             "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" \
             -o /tmp/buildkit.tgz
-          sudo tar -C /usr/local/bin --strip-components=1 -xzf /tmp/buildkit.tgz
+          tmp_dir="$(mktemp -d)"
+          tar -C "${tmp_dir}" -xzf /tmp/buildkit.tgz
+          sudo install -m 0755 "${tmp_dir}/bin/buildctl" /usr/local/bin/buildctl
+          sudo install -m 0755 "${tmp_dir}/bin/buildkitd" /usr/local/bin/buildkitd
+          sudo install -m 0755 "${tmp_dir}/bin/buildctl-daemonless.sh" /usr/local/bin/buildctl-daemonless.sh
           buildctl --version
 
       - name: Log in to Docker Hub

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -24,14 +24,14 @@ jobs:
       contents: read
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up BuildKit
         run: |
           curl -fsSL \
             "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" \
             -o /tmp/buildkit.tgz
-          sudo tar -C /usr/local --strip-components=1 -xzf /tmp/buildkit.tgz
+          sudo tar -C /usr/local/bin --strip-components=1 -xzf /tmp/buildkit.tgz
           buildctl --version
 
       - name: Log in to Docker Hub
@@ -87,14 +87,14 @@ jobs:
         java-version: ['17', '21']
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up BuildKit
         run: |
           curl -fsSL \
             "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" \
             -o /tmp/buildkit.tgz
-          sudo tar -C /usr/local --strip-components=1 -xzf /tmp/buildkit.tgz
+          sudo tar -C /usr/local/bin --strip-components=1 -xzf /tmp/buildkit.tgz
           buildctl --version
 
       - name: Log in to Docker Hub
@@ -154,14 +154,14 @@ jobs:
           - gatling-debug
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up BuildKit
         run: |
           curl -fsSL \
             "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" \
             -o /tmp/buildkit.tgz
-          sudo tar -C /usr/local --strip-components=1 -xzf /tmp/buildkit.tgz
+          sudo tar -C /usr/local/bin --strip-components=1 -xzf /tmp/buildkit.tgz
           buildctl --version
 
       - name: Log in to Docker Hub

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -35,7 +35,6 @@ jobs:
           tar -C "${tmp_dir}" -xzf /tmp/buildkit.tgz
           sudo install -m 0755 "${tmp_dir}/bin/buildctl" /usr/local/bin/buildctl
           sudo install -m 0755 "${tmp_dir}/bin/buildkitd" /usr/local/bin/buildkitd
-          sudo install -m 0755 "${tmp_dir}/bin/buildctl-daemonless.sh" /usr/local/bin/buildctl-daemonless.sh
           buildctl --version
 
       - name: Log in to Docker Hub
@@ -102,7 +101,6 @@ jobs:
           tar -C "${tmp_dir}" -xzf /tmp/buildkit.tgz
           sudo install -m 0755 "${tmp_dir}/bin/buildctl" /usr/local/bin/buildctl
           sudo install -m 0755 "${tmp_dir}/bin/buildkitd" /usr/local/bin/buildkitd
-          sudo install -m 0755 "${tmp_dir}/bin/buildctl-daemonless.sh" /usr/local/bin/buildctl-daemonless.sh
           buildctl --version
 
       - name: Log in to Docker Hub
@@ -173,7 +171,6 @@ jobs:
           tar -C "${tmp_dir}" -xzf /tmp/buildkit.tgz
           sudo install -m 0755 "${tmp_dir}/bin/buildctl" /usr/local/bin/buildctl
           sudo install -m 0755 "${tmp_dir}/bin/buildkitd" /usr/local/bin/buildkitd
-          sudo install -m 0755 "${tmp_dir}/bin/buildctl-daemonless.sh" /usr/local/bin/buildctl-daemonless.sh
           buildctl --version
 
       - name: Log in to Docker Hub


### PR DESCRIPTION
## Summary
- replace Docker Buildx action workflow logic with daemonless BuildKit builds
- add automatic semantic versioning and git tag creation on pushes to `main`
- publish versioned Docker images and create a GitHub Release with generated changelog

## Details
- adds `.github/scripts/buildkit-build.sh` as the common BuildKit entrypoint
- splits release pipeline into base, java, and Gatling image jobs so `base-jdk` waits for fresh `base`
- keeps PR builds on BuildKit with registry cache and sha-based tags
- mirrors the version bump and changelog flow used in `gatling-picatinny`

## Notes
- local shell and YAML parsing checks passed
- GitHub Actions execution still needs to run in CI for full validation