### PR TITLE
fix(ci): quote buildkit multi-tag outputs

### DIFF
--- a/.github/scripts/buildkit-build.sh
+++ b/.github/scripts/buildkit-build.sh
@@ -11,7 +11,10 @@ CONTEXT_DIR="${CONTEXT_DIR:-.}"
 PUSH_IMAGE="${PUSH_IMAGE:-true}"
 OUTPUT_FLAGS="${OUTPUT_FLAGS:-oci-mediatypes=true,name-canonical=true,push=${PUSH_IMAGE}}"
 
-mapfile -t tag_lines < <(printf '%s\n' "${IMAGE_TAGS}" | sed '/^[[:space:]]*$/d')
+tag_lines=()
+while IFS= read -r tag_line; do
+  tag_lines+=("${tag_line}")
+done < <(printf '%s\n' "${IMAGE_TAGS}" | sed '/^[[:space:]]*$/d')
 
 if [[ "${#tag_lines[@]}" -eq 0 ]]; then
   echo "No image tags provided" >&2
@@ -24,6 +27,7 @@ for tag in "${tag_lines[@]}"; do
 done
 
 image_names_csv="$(IFS=,; echo "${image_refs[*]}")"
+image_output="type=image,\"name=${image_names_csv}\",${OUTPUT_FLAGS}"
 
 buildctl_args=(
   --addr "${BUILDKIT_ADDR:-tcp://127.0.0.1:1234}"
@@ -34,7 +38,7 @@ buildctl_args=(
   --opt "filename=${DOCKERFILE_PATH}"
   --import-cache "type=registry,ref=${CACHE_REF}"
   --export-cache "type=registry,ref=${CACHE_REF},mode=max,image-manifest=true,oci-mediatypes=true"
-  --output "type=image,name=${image_names_csv},${OUTPUT_FLAGS}"
+  --output "${image_output}"
 )
 
 if [[ -n "${BUILD_ARGS:-}" ]]; then

--- a/tests/test_buildkit_build.sh
+++ b/tests/test_buildkit_build.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(CDPATH='' cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="${REPO_ROOT}/.github/scripts/buildkit-build.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  local file="$1"
+  local pattern="$2"
+  grep -F -- "$pattern" "$file" >/dev/null 2>&1 || fail "expected '$pattern' in $file"
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT INT TERM
+
+mockbin="${tmpdir}/mockbin"
+log_file="${tmpdir}/commands.log"
+args_file="${tmpdir}/build.args"
+mkdir -p "${mockbin}"
+
+cat > "${mockbin}/buildctl" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >> "${log_file}"
+if [[ "\${1:-}" == "--addr" && "\${3:-}" == "debug" && "\${4:-}" == "workers" ]]; then
+  exit 0
+fi
+printf '%s\n' "\$@" > "${args_file}"
+EOF
+chmod +x "${mockbin}/buildctl"
+
+cat > "${mockbin}/buildkitd" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+sleep 30
+EOF
+chmod +x "${mockbin}/buildkitd"
+
+(
+  cd "${REPO_ROOT}"
+  PATH="${mockbin}:/usr/bin:/bin" \
+  IMAGE_NAME='docker.io/example/app' \
+  IMAGE_TAGS=$'latest\n0.1.0\nv0.1.0' \
+  DOCKERFILE_PATH='Dockerfile' \
+  CACHE_REF='docker.io/example/cache:app' \
+  BUILDKITD_BIN="${mockbin}/buildkitd" \
+  BUILDKIT_ADDR='tcp://127.0.0.1:1234' \
+  bash "${SCRIPT}"
+)
+
+assert_file_contains "${log_file}" "--addr tcp://127.0.0.1:1234 debug workers"
+assert_file_contains "${args_file}" "--addr"
+assert_file_contains "${args_file}" "build"
+assert_file_contains "${args_file}" "type=image,\"name=docker.io/example/app:latest,docker.io/example/app:0.1.0,docker.io/example/app:v0.1.0\",oci-mediatypes=true,name-canonical=true,push=true"
+
+printf 'PASS: buildkit helper multi-tag output\n'


### PR DESCRIPTION
## Summary
- quote BuildKit image output names so release jobs can push multiple tags
- make the helper compatible with older bash by avoiding `mapfile`
- add a regression test for multi-tag image output formatting

## Testing
- bash -n .github/scripts/buildkit-build.sh
- bash tests/test_buildkit_build.sh
- bash tests/test_sbt_warmup.sh