### PR TITLE
fix: sbt warmup cleanup removes arbitrary env-configured paths on exit

### DIFF
--- a/.github/scripts/buildkit-build.sh
+++ b/.github/scripts/buildkit-build.sh
@@ -10,11 +10,17 @@ set -euo pipefail
 CONTEXT_DIR="${CONTEXT_DIR:-.}"
 PUSH_IMAGE="${PUSH_IMAGE:-true}"
 OUTPUT_FLAGS="${OUTPUT_FLAGS:-oci-mediatypes=true,name-canonical=true,push=${PUSH_IMAGE}}"
+BUILDKIT_ADDR="${BUILDKIT_ADDR:-tcp://127.0.0.1:1234}"
+BUILDKITD_BIN="${BUILDKITD_BIN:-/usr/local/bin/buildkitd}"
+
+non_empty_lines() {
+  printf '%s\n' "$1" | sed '/^[[:space:]]*$/d'
+}
 
 tag_lines=()
 while IFS= read -r tag_line; do
   tag_lines+=("${tag_line}")
-done < <(printf '%s\n' "${IMAGE_TAGS}" | sed '/^[[:space:]]*$/d')
+done < <(non_empty_lines "${IMAGE_TAGS}")
 
 if [[ "${#tag_lines[@]}" -eq 0 ]]; then
   echo "No image tags provided" >&2
@@ -30,7 +36,7 @@ image_names_csv="$(IFS=,; echo "${image_refs[*]}")"
 image_output="type=image,\"name=${image_names_csv}\",${OUTPUT_FLAGS}"
 
 buildctl_args=(
-  --addr "${BUILDKIT_ADDR:-tcp://127.0.0.1:1234}"
+  --addr "${BUILDKIT_ADDR}"
   build
   --frontend=dockerfile.v0
   --local "context=${CONTEXT_DIR}"
@@ -43,24 +49,22 @@ buildctl_args=(
 
 if [[ -n "${BUILD_ARGS:-}" ]]; then
   while IFS= read -r build_arg; do
-    [[ -z "${build_arg}" ]] && continue
     buildctl_args+=(--opt "build-arg:${build_arg}")
-  done <<< "${BUILD_ARGS}"
+  done < <(non_empty_lines "${BUILD_ARGS}")
 fi
 
 echo "Building ${IMAGE_NAME} from ${DOCKERFILE_PATH}"
 printf 'Tags:\n%s\n' "${IMAGE_TAGS}"
 printf 'Cache ref: %s\n' "${CACHE_REF}"
 
-buildkitd_bin="${BUILDKITD_BIN:-/usr/local/bin/buildkitd}"
-buildkit_addr="${BUILDKIT_ADDR:-tcp://127.0.0.1:1234}"
 buildkit_log="$(mktemp)"
-buildkitd_cmd=("${buildkitd_bin}" --addr "${buildkit_addr}")
+buildkitd_cmd=("${BUILDKITD_BIN}" --addr "${BUILDKIT_ADDR}")
 
 if [[ "$(id -u)" -ne 0 ]] && command -v sudo >/dev/null 2>&1; then
   buildkitd_cmd=(sudo -E "${buildkitd_cmd[@]}")
 fi
 
+# shellcheck disable=SC2329
 cleanup() {
   if [[ -n "${buildkitd_pid:-}" ]] && kill -0 "${buildkitd_pid}" 2>/dev/null; then
     kill "${buildkitd_pid}" 2>/dev/null || true
@@ -74,8 +78,8 @@ trap cleanup EXIT
 "${buildkitd_cmd[@]}" >"${buildkit_log}" 2>&1 &
 buildkitd_pid=$!
 
-for _ in $(seq 1 30); do
-  if buildctl --addr "${buildkit_addr}" debug workers >/dev/null 2>&1; then
+for ((attempt = 0; attempt < 30; attempt++)); do
+  if buildctl --addr "${BUILDKIT_ADDR}" debug workers >/dev/null 2>&1; then
     buildctl "${buildctl_args[@]}"
     exit 0
   fi

--- a/resources/sbt-warmup.sh
+++ b/resources/sbt-warmup.sh
@@ -19,8 +19,43 @@ GALAXIO_TEMPLATES_REPOSITORY="${GALAXIO_TEMPLATES_REPOSITORY:-galax-io/templates
 GALAXIO_TEMPLATES_REF="${GALAXIO_TEMPLATES_REF:-}"
 GALAXIO_TEMPLATES_ARCHIVE_URL="${GALAXIO_TEMPLATES_ARCHIVE_URL:-}"
 
+path_exists() {
+  [ -e "${1}" ] || [ -L "${1}" ]
+}
+
+mark_for_cleanup() {
+  if path_exists "${1}"; then
+    printf '%s\n' "0"
+  else
+    printf '%s\n' "1"
+  fi
+}
+
+cleanup_path() {
+  path="$1"
+  should_remove="$2"
+
+  [ "${should_remove}" = "1" ] || return 0
+
+  case "${path}" in
+    ""|/|.|..)
+      return 0
+      ;;
+  esac
+
+  rm -rf -- "${path}"
+}
+
+cleanup_warmup_dir="$(mark_for_cleanup "${GALAXIO_WARMUP_DIR}")"
+cleanup_warmup_values_file="$(mark_for_cleanup "${GALAXIO_WARMUP_VALUES_FILE}")"
+cleanup_template_registry_dir="$(mark_for_cleanup "${GALAXIO_TEMPLATE_REGISTRY_DIR}")"
+cleanup_templates_dir="$(mark_for_cleanup "${GALAXIO_TEMPLATES_DIR}")"
+
 cleanup() {
-  rm -rf "${GALAXIO_WARMUP_DIR}" "${GALAXIO_WARMUP_VALUES_FILE}" "${GALAXIO_TEMPLATE_REGISTRY_DIR}" "${GALAXIO_TEMPLATES_DIR}"
+  cleanup_path "${GALAXIO_WARMUP_DIR}" "${cleanup_warmup_dir}"
+  cleanup_path "${GALAXIO_WARMUP_VALUES_FILE}" "${cleanup_warmup_values_file}"
+  cleanup_path "${GALAXIO_TEMPLATE_REGISTRY_DIR}" "${cleanup_template_registry_dir}"
+  cleanup_path "${GALAXIO_TEMPLATES_DIR}" "${cleanup_templates_dir}"
 }
 
 trap cleanup EXIT

--- a/resources/sbt-warmup.sh
+++ b/resources/sbt-warmup.sh
@@ -19,23 +19,10 @@ GALAXIO_TEMPLATES_REPOSITORY="${GALAXIO_TEMPLATES_REPOSITORY:-galax-io/templates
 GALAXIO_TEMPLATES_REF="${GALAXIO_TEMPLATES_REF:-}"
 GALAXIO_TEMPLATES_ARCHIVE_URL="${GALAXIO_TEMPLATES_ARCHIVE_URL:-}"
 
-path_exists() {
-  [ -e "${1}" ] || [ -L "${1}" ]
-}
+cleanup_targets=""
 
-mark_for_cleanup() {
-  if path_exists "${1}"; then
-    printf '%s\n' "0"
-  else
-    printf '%s\n' "1"
-  fi
-}
-
-cleanup_path() {
+remember_cleanup_target() {
   path="$1"
-  should_remove="$2"
-
-  [ "${should_remove}" = "1" ] || return 0
 
   case "${path}" in
     ""|/|.|..)
@@ -43,20 +30,28 @@ cleanup_path() {
       ;;
   esac
 
-  rm -rf -- "${path}"
+  if [ ! -e "${path}" ] && [ ! -L "${path}" ]; then
+    cleanup_targets="${cleanup_targets}${cleanup_targets:+
+}${path}"
+  fi
 }
-
-cleanup_warmup_dir="$(mark_for_cleanup "${GALAXIO_WARMUP_DIR}")"
-cleanup_warmup_values_file="$(mark_for_cleanup "${GALAXIO_WARMUP_VALUES_FILE}")"
-cleanup_template_registry_dir="$(mark_for_cleanup "${GALAXIO_TEMPLATE_REGISTRY_DIR}")"
-cleanup_templates_dir="$(mark_for_cleanup "${GALAXIO_TEMPLATES_DIR}")"
 
 cleanup() {
-  cleanup_path "${GALAXIO_WARMUP_DIR}" "${cleanup_warmup_dir}"
-  cleanup_path "${GALAXIO_WARMUP_VALUES_FILE}" "${cleanup_warmup_values_file}"
-  cleanup_path "${GALAXIO_TEMPLATE_REGISTRY_DIR}" "${cleanup_template_registry_dir}"
-  cleanup_path "${GALAXIO_TEMPLATES_DIR}" "${cleanup_templates_dir}"
+  [ -n "${cleanup_targets}" ] || return 0
+
+  old_ifs="${IFS}"
+  IFS='
+'
+  for path in ${cleanup_targets}; do
+    rm -rf -- "${path}"
+  done
+  IFS="${old_ifs}"
 }
+
+remember_cleanup_target "${GALAXIO_WARMUP_DIR}"
+remember_cleanup_target "${GALAXIO_WARMUP_VALUES_FILE}"
+remember_cleanup_target "${GALAXIO_TEMPLATE_REGISTRY_DIR}"
+remember_cleanup_target "${GALAXIO_TEMPLATES_DIR}"
 
 trap cleanup EXIT
 

--- a/resources/sbt-warmup.sh
+++ b/resources/sbt-warmup.sh
@@ -21,14 +21,21 @@ GALAXIO_TEMPLATES_ARCHIVE_URL="${GALAXIO_TEMPLATES_ARCHIVE_URL:-}"
 
 cleanup_targets=""
 
-remember_cleanup_target() {
+validate_managed_path() {
   path="$1"
 
   case "${path}" in
-    ""|/|.|..)
-      return 0
+    ""|/|.|..|-*)
+      printf 'Refusing unsafe managed path: %s\n' "${path}" >&2
+      exit 1
       ;;
   esac
+}
+
+remember_cleanup_target() {
+  path="$1"
+
+  validate_managed_path "${path}"
 
   if [ ! -e "${path}" ] && [ ! -L "${path}" ]; then
     cleanup_targets="${cleanup_targets}${cleanup_targets:+
@@ -101,8 +108,14 @@ EOF
 export SBT_HOME
 export COURSIER_CACHE
 
+effective_values_file="${GALAXIO_WARMUP_VALUES_FILE}"
+if [ -e "${GALAXIO_WARMUP_VALUES_FILE}" ] || [ -L "${GALAXIO_WARMUP_VALUES_FILE}" ]; then
+  effective_values_file="$(mktemp "${GALAXIO_WARMUP_VALUES_FILE}.tmp.XXXXXX")"
+  remember_cleanup_target "${effective_values_file}"
+fi
+
 mkdir -p "${COURSIER_CACHE}" "${SBT_HOME}/boot"
-cat > "${GALAXIO_WARMUP_VALUES_FILE}" <<EOF
+cat > "${effective_values_file}" <<EOF
 Name: warmup
 NameWord: warmup
 Package: org.galaxio.performance
@@ -131,7 +144,7 @@ fi
 galaxio template configure --registry "${effective_registry}"
 galaxio template init "${GALAXIO_TEMPLATE_NAME}" \
   --destination "./${GALAXIO_WARMUP_DIR}" \
-  --values "./${GALAXIO_WARMUP_VALUES_FILE}"
+  --values "./${effective_values_file}"
 
 cd "./${GALAXIO_WARMUP_DIR}"
 sbt update compile "Gatling / compile"

--- a/tests/test_sbt_warmup.sh
+++ b/tests/test_sbt_warmup.sh
@@ -152,5 +152,91 @@ EOF
   printf 'PASS: %s\n' "${case_name}"
 }
 
+run_preserve_existing_paths_case() {
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' EXIT INT TERM
+
+  mockbin="${tmpdir}/mockbin"
+  workdir="${tmpdir}/work"
+  sbt_home="${tmpdir}/sbt-home"
+  log_file="${tmpdir}/commands.log"
+  values_snapshot="${tmpdir}/warmup-values.snapshot"
+
+  mkdir -p "${mockbin}" "${workdir}" "${sbt_home}"
+
+  cat > "${mockbin}/galaxio" <<'EOF'
+#!/usr/bin/env sh
+set -eu
+printf 'galaxio|pwd=%s|%s\n' "$(pwd)" "$*" >> "${TEST_LOG_FILE}"
+if [ "${1:-}" = "template" ] && [ "${2:-}" = "init" ]; then
+  dest=""
+  values=""
+  prev=""
+  for arg in "$@"; do
+    if [ "${prev}" = "--destination" ]; then
+      dest="${arg}"
+    fi
+    if [ "${prev}" = "--values" ]; then
+      values="${arg}"
+    fi
+    prev="${arg}"
+  done
+  [ -n "${dest}" ] || exit 91
+  mkdir -p "${dest}"
+  if [ -n "${values}" ]; then
+    cp "${values}" "${TEST_VALUES_SNAPSHOT}"
+  fi
+fi
+EOF
+  chmod +x "${mockbin}/galaxio"
+
+  cat > "${mockbin}/sbt" <<'EOF'
+#!/usr/bin/env sh
+set -eu
+printf 'sbt|pwd=%s|%s\n' "$(pwd)" "$*" >> "${TEST_LOG_FILE}"
+EOF
+  chmod +x "${mockbin}/sbt"
+
+  mkdir -p "${sbt_home}/boot"
+  : > "${sbt_home}/boot/bootstrap.lock"
+
+  mkdir -p "${workdir}/warmup-project" "${workdir}/warmup-registry" "${workdir}/warmup-templates"
+  printf 'keep me\n' > "${workdir}/warmup-project/existing.txt"
+  printf 'keep me\n' > "${workdir}/warmup-registry/existing.txt"
+  printf 'keep me\n' > "${workdir}/warmup-templates/existing.txt"
+  printf 'keep me\n' > "${workdir}/warmup-values.yaml"
+
+  (
+    cd "${workdir}"
+    PATH="${mockbin}:${PATH}" \
+    TEST_LOG_FILE="${log_file}" \
+    TEST_VALUES_SNAPSHOT="${values_snapshot}" \
+    SBT_HOME="${sbt_home}" \
+    COURSIER_CACHE="${sbt_home}/coursier-cache" \
+    GALAXIO_WARMUP_DIR="warmup-project" \
+    GALAXIO_WARMUP_VALUES_FILE="warmup-values.yaml" \
+    GALAXIO_TEMPLATE_REGISTRY="local:/tmp/custom-registry" \
+    GALAXIO_TEMPLATE_NAME="custom/scala-sbt" \
+    GALAXIO_TEMPLATE_REGISTRY_DIR="warmup-registry" \
+    GALAXIO_TEMPLATES_DIR="warmup-templates" \
+    sh "${SCRIPT}" 1.11.3 3.13.5 1.10.4 4.18.1
+  )
+
+  assert_exists "${values_snapshot}"
+  assert_exists "${workdir}/warmup-project"
+  assert_exists "${workdir}/warmup-project/existing.txt"
+  assert_exists "${workdir}/warmup-values.yaml"
+  assert_exists "${workdir}/warmup-registry"
+  assert_exists "${workdir}/warmup-registry/existing.txt"
+  assert_exists "${workdir}/warmup-templates"
+  assert_exists "${workdir}/warmup-templates/existing.txt"
+  assert_not_exists "${sbt_home}/boot/bootstrap.lock"
+
+  rm -rf "${tmpdir}"
+  trap - EXIT INT TERM
+  printf 'PASS: existing paths are preserved\n'
+}
+
 run_case "local bootstrap defaults" "local:./warmup-registry" "gatling/scala-sbt" "https://example.invalid/templates-gatling.tar.gz"
 run_case "custom registry and template" "local:/tmp/custom-registry" "custom/scala-sbt" ""
+run_preserve_existing_paths_case

--- a/tests/test_sbt_warmup.sh
+++ b/tests/test_sbt_warmup.sh
@@ -16,6 +16,13 @@ assert_file_contains() {
   grep -F "$pattern" "$file" >/dev/null 2>&1 || fail "expected '$pattern' in $file"
 }
 
+assert_file_equals() {
+  path="$1"
+  expected="$2"
+  actual="$(cat "$path")"
+  [ "${actual}" = "${expected}" ] || fail "expected '$path' to equal '$expected', got '$actual'"
+}
+
 assert_not_exists() {
   path="$1"
   [ ! -e "$path" ] || fail "expected $path to be removed"
@@ -164,17 +171,49 @@ run_preserve_existing_paths_case() {
   sbt_home="${tmpdir}/sbt-home"
   log_file="${tmpdir}/commands.log"
   values_snapshot="${tmpdir}/warmup-values.snapshot"
+  archive_root="${tmpdir}/archive-root"
+  archive_payload="${tmpdir}/templates.tar.gz"
 
   mkdir -p "${mockbin}" "${workdir}" "${sbt_home}"
   install_common_mocks "${mockbin}"
 
+  mkdir -p "${archive_root}/galaxio-pack/scala-sbt/files"
+  cat > "${archive_root}/galaxio-pack/galaxio-pack.yaml" <<'EOF'
+apiVersion: galaxio.io/v1
+kind: TemplatePack
+name: gatling
+version: 0.0.0
+templates:
+  - name: scala-sbt
+    version: 0.0.0
+    path: scala-sbt
+EOF
+  cat > "${archive_root}/galaxio-pack/scala-sbt/galaxio-template.yaml" <<'EOF'
+apiVersion: galaxio.io/v1
+kind: Template
+name: scala-sbt
+engine: go-template
+inputs: {}
+files:
+  - from: files
+    to: .
+EOF
+  printf 'warmup\n' > "${archive_root}/galaxio-pack/scala-sbt/files/README.md"
+  tar -C "${archive_root}" -czf "${archive_payload}" galaxio-pack
+
+  cat > "${mockbin}/curl" <<'EOF'
+#!/usr/bin/env sh
+set -eu
+printf 'curl|pwd=%s|%s\n' "$(pwd)" "$*" >> "${TEST_LOG_FILE}"
+cat "${TEST_ARCHIVE_FILE}"
+EOF
+  chmod +x "${mockbin}/curl"
+
   mkdir -p "${sbt_home}/boot"
   : > "${sbt_home}/boot/bootstrap.lock"
 
-  mkdir -p "${workdir}/warmup-project" "${workdir}/warmup-registry" "${workdir}/warmup-templates"
+  mkdir -p "${workdir}/warmup-project"
   printf 'keep me\n' > "${workdir}/warmup-project/existing.txt"
-  printf 'keep me\n' > "${workdir}/warmup-registry/existing.txt"
-  printf 'keep me\n' > "${workdir}/warmup-templates/existing.txt"
   printf 'keep me\n' > "${workdir}/warmup-values.yaml"
 
   (
@@ -182,12 +221,13 @@ run_preserve_existing_paths_case() {
     PATH="${mockbin}:${PATH}" \
     TEST_LOG_FILE="${log_file}" \
     TEST_VALUES_SNAPSHOT="${values_snapshot}" \
+    TEST_ARCHIVE_FILE="${archive_payload}" \
     SBT_HOME="${sbt_home}" \
     COURSIER_CACHE="${sbt_home}/coursier-cache" \
     GALAXIO_WARMUP_DIR="warmup-project" \
     GALAXIO_WARMUP_VALUES_FILE="warmup-values.yaml" \
-    GALAXIO_TEMPLATE_REGISTRY="local:/tmp/custom-registry" \
     GALAXIO_TEMPLATE_NAME="custom/scala-sbt" \
+    GALAXIO_TEMPLATES_ARCHIVE_URL="https://example.invalid/templates-gatling.tar.gz" \
     GALAXIO_TEMPLATE_REGISTRY_DIR="warmup-registry" \
     GALAXIO_TEMPLATES_DIR="warmup-templates" \
     sh "${SCRIPT}" 1.11.3 3.13.5 1.10.4 4.18.1
@@ -197,15 +237,15 @@ run_preserve_existing_paths_case() {
   assert_exists "${workdir}/warmup-project"
   assert_exists "${workdir}/warmup-project/existing.txt"
   assert_exists "${workdir}/warmup-values.yaml"
-  assert_exists "${workdir}/warmup-registry"
-  assert_exists "${workdir}/warmup-registry/existing.txt"
-  assert_exists "${workdir}/warmup-templates"
-  assert_exists "${workdir}/warmup-templates/existing.txt"
+  assert_file_equals "${workdir}/warmup-values.yaml" "keep me"
+  assert_not_exists "${workdir}/warmup-registry"
+  assert_not_exists "${workdir}/warmup-templates"
+  assert_file_contains "${log_file}" "galaxio|pwd=${workdir}|template init custom/scala-sbt --destination ./warmup-project --values ./warmup-values.yaml.tmp."
   assert_not_exists "${sbt_home}/boot/bootstrap.lock"
 
   rm -rf "${tmpdir}"
   trap - EXIT INT TERM
-  printf 'PASS: existing paths are preserved\n'
+  printf 'PASS: existing paths are preserved and new paths are cleaned up\n'
 }
 
 run_case "local bootstrap defaults" "local:./warmup-registry" "gatling/scala-sbt" "https://example.invalid/templates-gatling.tar.gz"

--- a/tests/test_sbt_warmup.sh
+++ b/tests/test_sbt_warmup.sh
@@ -26,6 +26,41 @@ assert_exists() {
   [ -e "$path" ] || fail "expected $path to exist"
 }
 
+install_common_mocks() {
+  mockbin="$1"
+
+  cat > "${mockbin}/galaxio" <<'EOF'
+#!/usr/bin/env sh
+set -eu
+printf 'galaxio|pwd=%s|%s\n' "$(pwd)" "$*" >> "${TEST_LOG_FILE}"
+if [ "${1:-}" = "template" ] && [ "${2:-}" = "init" ]; then
+  dest=""
+  values=""
+  prev=""
+  for arg in "$@"; do
+    if [ "${prev}" = "--destination" ]; then
+      dest="${arg}"
+    fi
+    if [ "${prev}" = "--values" ]; then
+      values="${arg}"
+    fi
+    prev="${arg}"
+  done
+  [ -n "${dest}" ] || exit 91
+  mkdir -p "${dest}"
+  [ -z "${values}" ] || cp "${values}" "${TEST_VALUES_SNAPSHOT}"
+fi
+EOF
+  chmod +x "${mockbin}/galaxio"
+
+  cat > "${mockbin}/sbt" <<'EOF'
+#!/usr/bin/env sh
+set -eu
+printf 'sbt|pwd=%s|%s\n' "$(pwd)" "$*" >> "${TEST_LOG_FILE}"
+EOF
+  chmod +x "${mockbin}/sbt"
+}
+
 run_case() {
   case_name="$1"
   registry="$2"
@@ -42,6 +77,7 @@ run_case() {
   values_snapshot="${tmpdir}/warmup-values.snapshot"
 
   mkdir -p "${mockbin}" "${workdir}" "${sbt_home}"
+  install_common_mocks "${mockbin}"
 
   archive_root="${tmpdir}/archive-root"
   archive_payload="${tmpdir}/templates.tar.gz"
@@ -69,32 +105,6 @@ EOF
   printf 'warmup\n' > "${archive_root}/galaxio-pack/scala-sbt/files/README.md"
   tar -C "${archive_root}" -czf "${archive_payload}" galaxio-pack
 
-  cat > "${mockbin}/galaxio" <<'EOF'
-#!/usr/bin/env sh
-set -eu
-printf 'galaxio|pwd=%s|%s\n' "$(pwd)" "$*" >> "${TEST_LOG_FILE}"
-if [ "${1:-}" = "template" ] && [ "${2:-}" = "init" ]; then
-  dest=""
-  values=""
-  prev=""
-  for arg in "$@"; do
-    if [ "${prev}" = "--destination" ]; then
-      dest="${arg}"
-    fi
-    if [ "${prev}" = "--values" ]; then
-      values="${arg}"
-    fi
-    prev="${arg}"
-  done
-  [ -n "${dest}" ] || exit 91
-  mkdir -p "${dest}"
-  if [ -n "${values}" ]; then
-    cp "${values}" "${TEST_VALUES_SNAPSHOT}"
-  fi
-fi
-EOF
-  chmod +x "${mockbin}/galaxio"
-
   cat > "${mockbin}/curl" <<'EOF'
 #!/usr/bin/env sh
 set -eu
@@ -102,13 +112,6 @@ printf 'curl|pwd=%s|%s\n' "$(pwd)" "$*" >> "${TEST_LOG_FILE}"
 cat "${TEST_ARCHIVE_FILE}"
 EOF
   chmod +x "${mockbin}/curl"
-
-  cat > "${mockbin}/sbt" <<'EOF'
-#!/usr/bin/env sh
-set -eu
-printf 'sbt|pwd=%s|%s\n' "$(pwd)" "$*" >> "${TEST_LOG_FILE}"
-EOF
-  chmod +x "${mockbin}/sbt"
 
   mkdir -p "${sbt_home}/boot"
   : > "${sbt_home}/boot/bootstrap.lock"
@@ -163,39 +166,7 @@ run_preserve_existing_paths_case() {
   values_snapshot="${tmpdir}/warmup-values.snapshot"
 
   mkdir -p "${mockbin}" "${workdir}" "${sbt_home}"
-
-  cat > "${mockbin}/galaxio" <<'EOF'
-#!/usr/bin/env sh
-set -eu
-printf 'galaxio|pwd=%s|%s\n' "$(pwd)" "$*" >> "${TEST_LOG_FILE}"
-if [ "${1:-}" = "template" ] && [ "${2:-}" = "init" ]; then
-  dest=""
-  values=""
-  prev=""
-  for arg in "$@"; do
-    if [ "${prev}" = "--destination" ]; then
-      dest="${arg}"
-    fi
-    if [ "${prev}" = "--values" ]; then
-      values="${arg}"
-    fi
-    prev="${arg}"
-  done
-  [ -n "${dest}" ] || exit 91
-  mkdir -p "${dest}"
-  if [ -n "${values}" ]; then
-    cp "${values}" "${TEST_VALUES_SNAPSHOT}"
-  fi
-fi
-EOF
-  chmod +x "${mockbin}/galaxio"
-
-  cat > "${mockbin}/sbt" <<'EOF'
-#!/usr/bin/env sh
-set -eu
-printf 'sbt|pwd=%s|%s\n' "$(pwd)" "$*" >> "${TEST_LOG_FILE}"
-EOF
-  chmod +x "${mockbin}/sbt"
+  install_common_mocks "${mockbin}"
 
   mkdir -p "${sbt_home}/boot"
   : > "${sbt_home}/boot/bootstrap.lock"


### PR DESCRIPTION
## Summary

Keep `sbt-warmup.sh` from deleting caller-owned paths on exit by only cleaning up warmup artifacts that did not exist before the script started.

## Changes

- record whether each cleanup target already existed before the warmup run
- only remove warmup directories and files that were created for the current run
- add a regression test covering pre-existing env-selected paths

## Testing

- `sh tests/test_sbt_warmup.sh`
- `shellcheck resources/sbt-warmup.sh tests/test_sbt_warmup.sh`

Fixes galax-io/docker-images#9