### PR TITLE
fix(ci): stop pushing images to registry on pull requests

### DIFF
--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -68,7 +68,7 @@ jobs:
             echo "EOF"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Build and push image with BuildKit
+      - name: Build image with BuildKit
         env:
           IMAGE_NAME: ${{ steps.meta.outputs.image_name }}
           IMAGE_TAGS: ${{ steps.meta.outputs.image_tags }}
@@ -76,6 +76,7 @@ jobs:
           CACHE_REF: ${{ steps.meta.outputs.cache_ref }}
           BUILD_ARGS: ${{ steps.meta.outputs.build_args }}
           CONTEXT_DIR: ${{ env.BUILD_CONTEXT }}
+          PUSH_IMAGE: "false"
         run: ./.github/scripts/buildkit-build.sh
 
   build-java:
@@ -120,7 +121,7 @@ jobs:
           dockerfile_path="java.Dockerfile"
           cache_ref="${CACHE_REPOSITORY}:base-jdk-${{ matrix.java-version }}-pr"
           image_tags="${{ matrix.java-version }}-${sha_tag}"
-          build_args=$'BASE_VERSION='"${sha_tag}"$'\nJAVA_VERSION=${{ matrix.java-version }}'
+          build_args=$'BASE_VERSION=latest\nJAVA_VERSION=${{ matrix.java-version }}'
 
           {
             echo "image_name=${image_name}"
@@ -134,7 +135,7 @@ jobs:
             echo "EOF"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Build and push image with BuildKit
+      - name: Build image with BuildKit
         env:
           IMAGE_NAME: ${{ steps.meta.outputs.image_name }}
           IMAGE_TAGS: ${{ steps.meta.outputs.image_tags }}
@@ -142,6 +143,7 @@ jobs:
           CACHE_REF: ${{ steps.meta.outputs.cache_ref }}
           BUILD_ARGS: ${{ steps.meta.outputs.build_args }}
           CONTEXT_DIR: ${{ env.BUILD_CONTEXT }}
+          PUSH_IMAGE: "false"
         run: ./.github/scripts/buildkit-build.sh
 
   build-gatling-images:
@@ -241,7 +243,7 @@ jobs:
             echo "EOF"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Build and push image with BuildKit
+      - name: Build image with BuildKit
         env:
           IMAGE_NAME: ${{ steps.meta.outputs.image_name }}
           IMAGE_TAGS: ${{ steps.meta.outputs.image_tags }}
@@ -249,4 +251,5 @@ jobs:
           CACHE_REF: ${{ steps.meta.outputs.cache_ref }}
           BUILD_ARGS: ${{ steps.meta.outputs.build_args }}
           CONTEXT_DIR: ${{ env.BUILD_CONTEXT }}
+          PUSH_IMAGE: "false"
         run: ./.github/scripts/buildkit-build.sh

--- a/tests/test_buildkit_build.sh
+++ b/tests/test_buildkit_build.sh
@@ -60,3 +60,23 @@ assert_file_contains "${args_file}" "build"
 assert_file_contains "${args_file}" "type=image,\"name=docker.io/example/app:latest,docker.io/example/app:0.1.0,docker.io/example/app:v0.1.0\",oci-mediatypes=true,name-canonical=true,push=true"
 
 printf 'PASS: buildkit helper multi-tag output\n'
+
+: > "${log_file}"
+: > "${args_file}"
+
+(
+  cd "${REPO_ROOT}"
+  PATH="${mockbin}:/usr/bin:/bin" \
+  IMAGE_NAME='docker.io/example/app' \
+  IMAGE_TAGS='latest' \
+  DOCKERFILE_PATH='Dockerfile' \
+  CACHE_REF='docker.io/example/cache:app' \
+  BUILDKITD_BIN="${mockbin}/buildkitd" \
+  BUILDKIT_ADDR='tcp://127.0.0.1:1234' \
+  PUSH_IMAGE='false' \
+  bash "${SCRIPT}"
+)
+
+assert_file_contains "${args_file}" "push=false"
+
+printf 'PASS: buildkit helper respects PUSH_IMAGE=false\n'


### PR DESCRIPTION
## Summary

- Set `PUSH_IMAGE=false` for all PR build jobs so unmerged changes no longer publish SHA-tagged images to Docker Hub
- Change `build-java` to use `BASE_VERSION=latest` instead of the unpushed SHA tag
- Add test case for `PUSH_IMAGE=false` in buildkit build helper

## Notes

- Docker Hub login is kept because BuildKit cache import/export still needs registry credentials
- `needs: build-base` dependency is kept on `build-java` to validate base Dockerfile builds successfully
- PR builds now verify Dockerfiles compile without polluting the registry

## Test plan

- [x] `bash tests/test_buildkit_build.sh` — both test cases pass
- [x] `shellcheck` passes on all scripts
- [ ] Verify PR CI runs build-only (no push) on this PR itself

Fixes galax-io/docker-images#14

🤖 Generated with [Claude Code](https://claude.com/claude-code)