### PR TITLE
test: add runtime smoke test for gatling-runtime container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -355,6 +355,13 @@ jobs:
           CONTEXT_DIR: ${{ env.BUILD_CONTEXT }}
         run: ./.github/scripts/buildkit-build.sh
 
+      - name: Runtime smoke test
+        shell: bash
+        run: |
+          set -euo pipefail
+          IMAGE="${{ steps.runtime-meta.outputs.image_name }}:$(printf '%s' '${{ steps.runtime-meta.outputs.image_tags }}' | head -n1)"
+          tests/test_runtime_smoke.sh "$IMAGE"
+
       - name: Prepare debug metadata
         id: debug-meta
         shell: bash

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -222,6 +222,13 @@ jobs:
           CONTEXT_DIR: ${{ env.BUILD_CONTEXT }}
         run: ./.github/scripts/buildkit-build.sh
 
+      - name: Runtime smoke test
+        shell: bash
+        run: |
+          set -euo pipefail
+          IMAGE="${{ steps.runtime-meta.outputs.image_name }}:$(printf '%s' '${{ steps.runtime-meta.outputs.image_tags }}' | head -n1)"
+          tests/test_runtime_smoke.sh "$IMAGE"
+
       - name: Prepare debug metadata
         id: debug-meta
         shell: bash

--- a/tests/test_runtime_smoke.sh
+++ b/tests/test_runtime_smoke.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Smoke test for gatling-runtime container images.
+# Usage: tests/test_runtime_smoke.sh <image>
+# Verifies: non-root UID (65532), build tool reachability, entrypoint resolution.
+
+set -euo pipefail
+
+IMAGE="${1:-${IMAGE:-}}"
+if [[ -z "$IMAGE" ]]; then
+  echo "Usage: $0 <image>" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "Smoke-testing image: $IMAGE"
+echo ""
+
+# Pull image once so docker run output is not mixed into captured variables.
+docker pull "$IMAGE" >/dev/null 2>&1
+
+# Test 1: container runs as non-root user (UID 65532 = nonroot)
+UID_OUTPUT=$(docker run --rm "$IMAGE" "id -u")
+if [[ "$UID_OUTPUT" == "65532" ]]; then
+  pass "non-root UID (65532)"
+else
+  fail "expected UID 65532, got: ${UID_OUTPUT}"
+fi
+
+# Test 2: build tool reachable (auto-detect sbt / mvn / gradle)
+BUILD_TOOL_OK=false
+if docker run --rm "$IMAGE" "sbt --version" >/dev/null 2>&1; then
+  pass "sbt reachable"
+  BUILD_TOOL_OK=true
+elif docker run --rm "$IMAGE" "mvn --version" >/dev/null 2>&1; then
+  pass "mvn reachable"
+  BUILD_TOOL_OK=true
+elif docker run --rm "$IMAGE" "gradle --version" >/dev/null 2>&1; then
+  pass "gradle reachable"
+  BUILD_TOOL_OK=true
+fi
+if ! $BUILD_TOOL_OK; then
+  fail "no build tool (sbt/mvn/gradle) reachable"
+fi
+
+# Test 3: entrypoint resolves cleanly (container exits 0)
+if docker run --rm "$IMAGE" "exit 0" >/dev/null 2>&1; then
+  pass "entrypoint resolves"
+else
+  fail "entrypoint did not resolve cleanly"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

- Adds `tests/test_runtime_smoke.sh` that verifies the gatling-runtime container boots correctly
- Asserts non-root UID (65532), build tool reachability (sbt/mvn/gradle auto-detected), and entrypoint resolution
- Wired into CI as a step after each runtime image push in the `build-gatling-chain` job (covers all 6 matrix combinations: sbt/maven/gradle × java-17/java-21)

## Changes

- New `tests/test_runtime_smoke.sh` (executable)
- `.github/workflows/build.yml`: "Runtime smoke test" step added after "Build and push runtime image"

## Testing

Script validated for bash syntax. Uses `set -euo pipefail` and exits non-zero if any assertion fails, which will fail the CI job.

Fixes galax-io/docker-images#31