### PR TITLE
sec: add SHA256 verification for galaxio-cli in gatling-sbt-builder.Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,32 @@ Build:
 docker build -f gatling-sbt-builder.Dockerfile -t galaxioteam/gatling-sbt-builder:local .
 ```
 
+#### Build arguments
+
+| Argument | Default | Description |
+|---|---|---|
+| `GALAXIO_CLI_VERSION` | `0.6.1` | Version of `galaxio-cli` to download. |
+| `GALAXIO_CLI_CHECKSUM` | _(see Dockerfile)_ | SHA256 checksum of the `galaxio-cli` release tarball. Used to verify the download before extraction. |
+
+**`GALAXIO_CLI_CHECKSUM`** — how to find and use it:
+
+1. Open the release page for the target version:
+   `https://github.com/galax-io/galaxio-cli/releases/tag/v<VERSION>`
+2. Download `checksums.txt` from the release assets and locate the line for
+   `galaxio_<VERSION>_linux_amd64.tar.gz`.
+3. Pass the hash at build time:
+
+```bash
+docker build \
+  --build-arg GALAXIO_CLI_VERSION=0.6.1 \
+  --build-arg GALAXIO_CLI_CHECKSUM=711075adfa5bd7fc188326ee4200177cfd13d997082ecc27b304e405ae035fea \
+  -f gatling-sbt-builder.Dockerfile \
+  -t galaxioteam/gatling-sbt-builder:local .
+```
+
+If `GALAXIO_CLI_CHECKSUM` does not match the downloaded file, the build will
+fail at the `sha256sum -c` step before any binary is extracted.
+
 ### `gatling-maven-builder.Dockerfile`
 
 Builder image for Gatling Maven projects:

--- a/gatling-sbt-builder.Dockerfile
+++ b/gatling-sbt-builder.Dockerfile
@@ -6,6 +6,9 @@ ARG GATLING_VERSION=3.13.5
 ARG GATLING_SBT_VERSION=4.18.1
 ARG PICATINNY_VERSION=1.12.3
 ARG GALAXIO_CLI_VERSION=0.6.1
+# SHA256 checksum of galaxio-cli binary release for verification.
+# See: https://github.com/galax-io/galaxio-cli/releases/download/v${GALAXIO_CLI_VERSION}/checksums.txt
+ARG GALAXIO_CLI_CHECKSUM=711075adfa5bd7fc188326ee4200177cfd13d997082ecc27b304e405ae035fea
 
 # Warmup: official sbt image (has JDK + sbt + scala + bash + curl)
 # Uses `galaxio template init` with all plugins (kafka, jdbc, amqp) enabled
@@ -17,6 +20,7 @@ ARG GATLING_VERSION
 ARG GATLING_SBT_VERSION
 ARG PICATINNY_VERSION
 ARG GALAXIO_CLI_VERSION
+ARG GALAXIO_CLI_CHECKSUM
 
 ENV HOME=/home/sbtuser \
     SBT_HOME=/home/sbtuser/.sbt \
@@ -30,8 +34,11 @@ ENV HOME=/home/sbtuser \
 USER root
 RUN curl -fsSL \
       "https://github.com/galax-io/galaxio-cli/releases/download/v${GALAXIO_CLI_VERSION}/galaxio_${GALAXIO_CLI_VERSION}_linux_amd64.tar.gz" \
-      | tar -xz -C /usr/local/bin galaxio && \
-    chmod 0755 /usr/local/bin/galaxio
+      -o /tmp/galaxio.tar.gz && \
+    echo "${GALAXIO_CLI_CHECKSUM}  /tmp/galaxio.tar.gz" | sha256sum -c - && \
+    tar -xz -C /usr/local/bin -f /tmp/galaxio.tar.gz galaxio && \
+    chmod 0755 /usr/local/bin/galaxio && \
+    rm -f /tmp/galaxio.tar.gz
 
 USER sbtuser
 WORKDIR /home/sbtuser


### PR DESCRIPTION
## Summary

Adds `GALAXIO_CLI_CHECKSUM` ARG and verifies SHA256 before installing `galaxio-cli` binary, preventing silent supply-chain compromise via compromised GitHub release assets.

## Changes

- `gatling-sbt-builder.Dockerfile`: add `GALAXIO_CLI_CHECKSUM` ARG, verify SHA256 post-download

## Testing

Dockerfile syntax validated. Build fails on checksum mismatch.

Fixes galax-io/docker-images#29