### PR TITLE
test: add Gatling simulation smoke test in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -410,7 +410,7 @@ jobs:
           CONTEXT_DIR: ${{ env.BUILD_CONTEXT }}
         run: ./.github/scripts/buildkit-build.sh
 
-  test-gatling-smoke:
+  integration-tests:
     name: Smoke-test gatling-${{ matrix.tool }}-runtime (java ${{ matrix.java-version }})
     runs-on: ubuntu-24.04
     needs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -476,10 +476,12 @@ jobs:
               ;;
           esac
 
+          tmp_target="$(mktemp -d)"
           docker run --rm \
             -v "${FIXTURE_DIR}:/project" \
+            -v "${tmp_target}:/project/target" \
             "${IMAGE}" \
-            "${cmd}"
+            bash -c "${cmd}"
 
   changelog:
     name: Generate Changelog

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -410,6 +410,77 @@ jobs:
           CONTEXT_DIR: ${{ env.BUILD_CONTEXT }}
         run: ./.github/scripts/buildkit-build.sh
 
+  test-gatling-smoke:
+    name: Smoke-test gatling-${{ matrix.tool }}-runtime (java ${{ matrix.java-version }})
+    runs-on: ubuntu-24.04
+    needs:
+      - prepare-release
+      - build-gatling-chain
+    if: github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: ['17', '21']
+        tool: ['sbt', 'maven', 'gradle']
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v5
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Determine runtime image tag
+        id: image
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tool="${{ matrix.tool }}"
+          java_version="${{ matrix.java-version }}"
+          release_version="${{ needs.prepare-release.outputs.release_version }}"
+
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            tag="${java_version}-${release_version}"
+          else
+            tag="${java_version}"
+          fi
+
+          echo "ref=galaxioteam/gatling-${tool}-runtime:${tag}" >> "${GITHUB_OUTPUT}"
+
+      - name: Pull runtime image
+        run: docker pull "${{ steps.image.outputs.ref }}"
+
+      - name: Run Gatling BasicSimulation smoke test
+        shell: bash
+        env:
+          IMAGE: ${{ steps.image.outputs.ref }}
+          TOOL: ${{ matrix.tool }}
+          FIXTURE_DIR: ${{ github.workspace }}/tests/fixtures/${{ matrix.tool }}
+        run: |
+          set -euo pipefail
+
+          case "${TOOL}" in
+            sbt)
+              cmd='cd /project && sbt "gatling:testOnly computerdatabase.BasicSimulation"'
+              ;;
+            maven)
+              cmd='cd /project && mvn -q gatling:test -Dgatling.simulationClass=computerdatabase.BasicSimulation'
+              ;;
+            gradle)
+              cmd='cd /project && gradle --no-daemon gatlingRun -Dgatling.simulationClass=computerdatabase.BasicSimulation'
+              ;;
+          esac
+
+          docker run --rm \
+            -v "${FIXTURE_DIR}:/project" \
+            "${IMAGE}" \
+            "${cmd}"
+
   changelog:
     name: Generate Changelog
     runs-on: ubuntu-24.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -447,7 +447,8 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             tag="${java_version}-${release_version}"
           else
-            tag="${java_version}"
+            # Use SHA-tagged image pushed by build-gatling-chain in this same run to prevent drift.
+            tag="${java_version}-${{ github.sha }}"
           fi
 
           echo "ref=galaxioteam/gatling-${tool}-runtime:${tag}" >> "${GITHUB_OUTPUT}"
@@ -466,7 +467,7 @@ jobs:
 
           case "${TOOL}" in
             sbt)
-              cmd='cd /project && sbt "gatling:testOnly computerdatabase.BasicSimulation"'
+              cmd='cd /project && sbt "Gatling / testOnly computerdatabase.BasicSimulation"'
               ;;
             maven)
               cmd='cd /project && mvn -q gatling:test -Dgatling.simulationClass=computerdatabase.BasicSimulation'
@@ -477,6 +478,7 @@ jobs:
           esac
 
           tmp_target="$(mktemp -d)"
+          trap 'rm -rf "${tmp_target}"' EXIT
           docker run --rm \
             -v "${FIXTURE_DIR}:/project" \
             -v "${tmp_target}:/project/target" \

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -270,3 +270,53 @@ jobs:
           BUILD_ARGS: ${{ steps.debug-meta.outputs.build_args }}
           CONTEXT_DIR: ${{ env.BUILD_CONTEXT }}
         run: ./.github/scripts/buildkit-build.sh
+
+  test-gatling-smoke:
+    name: Smoke-test gatling-${{ matrix.tool }}-runtime (java ${{ matrix.java-version }})
+    runs-on: ubuntu-24.04
+    needs: build-gatling-chain
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: ['17', '21']
+        tool: ['sbt', 'maven', 'gradle']
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v5
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Pull runtime image
+        run: docker pull "galaxioteam/gatling-${{ matrix.tool }}-runtime:${{ matrix.java-version }}-${GITHUB_SHA}"
+
+      - name: Run Gatling BasicSimulation smoke test
+        shell: bash
+        env:
+          IMAGE: "galaxioteam/gatling-${{ matrix.tool }}-runtime:${{ matrix.java-version }}-${{ github.sha }}"
+          TOOL: ${{ matrix.tool }}
+          FIXTURE_DIR: ${{ github.workspace }}/tests/fixtures/${{ matrix.tool }}
+        run: |
+          set -euo pipefail
+
+          case "${TOOL}" in
+            sbt)
+              cmd='cd /project && sbt "gatling:testOnly computerdatabase.BasicSimulation"'
+              ;;
+            maven)
+              cmd='cd /project && mvn -q gatling:test -Dgatling.simulationClass=computerdatabase.BasicSimulation'
+              ;;
+            gradle)
+              cmd='cd /project && gradle --no-daemon gatlingRun -Dgatling.simulationClass=computerdatabase.BasicSimulation'
+              ;;
+          esac
+
+          docker run --rm \
+            -v "${FIXTURE_DIR}:/project" \
+            "${IMAGE}" \
+            "${cmd}"

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -271,7 +271,7 @@ jobs:
           CONTEXT_DIR: ${{ env.BUILD_CONTEXT }}
         run: ./.github/scripts/buildkit-build.sh
 
-  test-gatling-smoke:
+  integration-tests:
     name: Smoke-test gatling-${{ matrix.tool }}-runtime (java ${{ matrix.java-version }})
     runs-on: ubuntu-24.04
     needs: build-gatling-chain

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -316,7 +316,9 @@ jobs:
               ;;
           esac
 
+          tmp_target="$(mktemp -d)"
           docker run --rm \
             -v "${FIXTURE_DIR}:/project" \
+            -v "${tmp_target}:/project/target" \
             "${IMAGE}" \
-            "${cmd}"
+            bash -c "${cmd}"

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -293,7 +293,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Pull runtime image
-        run: docker pull "galaxioteam/gatling-${{ matrix.tool }}-runtime:${{ matrix.java-version }}-${GITHUB_SHA}"
+        run: docker pull "galaxioteam/gatling-${{ matrix.tool }}-runtime:${{ matrix.java-version }}-${{ github.sha }}"
 
       - name: Run Gatling BasicSimulation smoke test
         shell: bash
@@ -306,7 +306,7 @@ jobs:
 
           case "${TOOL}" in
             sbt)
-              cmd='cd /project && sbt "gatling:testOnly computerdatabase.BasicSimulation"'
+              cmd='cd /project && sbt "Gatling / testOnly computerdatabase.BasicSimulation"'
               ;;
             maven)
               cmd='cd /project && mvn -q gatling:test -Dgatling.simulationClass=computerdatabase.BasicSimulation'
@@ -317,6 +317,7 @@ jobs:
           esac
 
           tmp_target="$(mktemp -d)"
+          trap 'rm -rf "${tmp_target}"' EXIT
           docker run --rm \
             -v "${FIXTURE_DIR}:/project" \
             -v "${tmp_target}:/project/target" \

--- a/tests/fixtures/gradle/build.gradle
+++ b/tests/fixtures/gradle/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+  id 'java'
+  id 'io.gatling.gradle' version '3.13.5.4'
+}
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  gatling 'io.gatling.highcharts:gatling-charts-highcharts:3.13.5'
+}

--- a/tests/fixtures/gradle/settings.gradle
+++ b/tests/fixtures/gradle/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'gatling-smoke-test'

--- a/tests/fixtures/gradle/src/gatling/java/computerdatabase/BasicSimulation.java
+++ b/tests/fixtures/gradle/src/gatling/java/computerdatabase/BasicSimulation.java
@@ -8,6 +8,7 @@ import static io.gatling.javaapi.http.HttpDsl.status;
 import io.gatling.javaapi.core.ScenarioBuilder;
 import io.gatling.javaapi.core.Simulation;
 import io.gatling.javaapi.http.HttpProtocolBuilder;
+import java.time.Duration;
 
 public class BasicSimulation extends Simulation {
 
@@ -20,6 +21,6 @@ public class BasicSimulation extends Simulation {
           .exec(http("home").get("/").check(status().is(200)));
 
   {
-    setUp(scn.injectOpen(atOnceUsers(1))).protocols(httpProtocol);
+    setUp(scn.injectOpen(atOnceUsers(1))).protocols(httpProtocol).maxDuration(Duration.ofSeconds(30));
   }
 }

--- a/tests/fixtures/gradle/src/gatling/java/computerdatabase/BasicSimulation.java
+++ b/tests/fixtures/gradle/src/gatling/java/computerdatabase/BasicSimulation.java
@@ -1,0 +1,25 @@
+package computerdatabase;
+
+import static io.gatling.javaapi.core.CoreDsl.atOnceUsers;
+import static io.gatling.javaapi.core.CoreDsl.scenario;
+import static io.gatling.javaapi.http.HttpDsl.http;
+import static io.gatling.javaapi.http.HttpDsl.status;
+
+import io.gatling.javaapi.core.ScenarioBuilder;
+import io.gatling.javaapi.core.Simulation;
+import io.gatling.javaapi.http.HttpProtocolBuilder;
+
+public class BasicSimulation extends Simulation {
+
+  HttpProtocolBuilder httpProtocol =
+      http.baseUrl("https://computer-database.gatling.io")
+          .acceptHeader("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+
+  ScenarioBuilder scn =
+      scenario("BasicSimulation")
+          .exec(http("home").get("/").check(status().is(200)));
+
+  {
+    setUp(scn.injectOpen(atOnceUsers(1))).protocols(httpProtocol);
+  }
+}

--- a/tests/fixtures/maven/pom.xml
+++ b/tests/fixtures/maven/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.galaxio</groupId>
+  <artifactId>gatling-smoke-test</artifactId>
+  <version>1.0.0</version>
+  <properties>
+    <maven.compiler.release>11</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <gatling.version>3.13.5</gatling.version>
+    <gatling-maven-plugin.version>4.16.3</gatling-maven-plugin.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>io.gatling.highcharts</groupId>
+      <artifactId>gatling-charts-highcharts</artifactId>
+      <version>${gatling.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.gatling</groupId>
+        <artifactId>gatling-maven-plugin</artifactId>
+        <version>${gatling-maven-plugin.version}</version>
+        <configuration>
+          <simulationClass>computerdatabase.BasicSimulation</simulationClass>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tests/fixtures/maven/src/test/java/computerdatabase/BasicSimulation.java
+++ b/tests/fixtures/maven/src/test/java/computerdatabase/BasicSimulation.java
@@ -8,6 +8,7 @@ import static io.gatling.javaapi.http.HttpDsl.status;
 import io.gatling.javaapi.core.ScenarioBuilder;
 import io.gatling.javaapi.core.Simulation;
 import io.gatling.javaapi.http.HttpProtocolBuilder;
+import java.time.Duration;
 
 public class BasicSimulation extends Simulation {
 
@@ -20,6 +21,6 @@ public class BasicSimulation extends Simulation {
           .exec(http("home").get("/").check(status().is(200)));
 
   {
-    setUp(scn.injectOpen(atOnceUsers(1))).protocols(httpProtocol);
+    setUp(scn.injectOpen(atOnceUsers(1))).protocols(httpProtocol).maxDuration(Duration.ofSeconds(30));
   }
 }

--- a/tests/fixtures/maven/src/test/java/computerdatabase/BasicSimulation.java
+++ b/tests/fixtures/maven/src/test/java/computerdatabase/BasicSimulation.java
@@ -1,0 +1,25 @@
+package computerdatabase;
+
+import static io.gatling.javaapi.core.CoreDsl.atOnceUsers;
+import static io.gatling.javaapi.core.CoreDsl.scenario;
+import static io.gatling.javaapi.http.HttpDsl.http;
+import static io.gatling.javaapi.http.HttpDsl.status;
+
+import io.gatling.javaapi.core.ScenarioBuilder;
+import io.gatling.javaapi.core.Simulation;
+import io.gatling.javaapi.http.HttpProtocolBuilder;
+
+public class BasicSimulation extends Simulation {
+
+  HttpProtocolBuilder httpProtocol =
+      http.baseUrl("https://computer-database.gatling.io")
+          .acceptHeader("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+
+  ScenarioBuilder scn =
+      scenario("BasicSimulation")
+          .exec(http("home").get("/").check(status().is(200)));
+
+  {
+    setUp(scn.injectOpen(atOnceUsers(1))).protocols(httpProtocol);
+  }
+}

--- a/tests/fixtures/sbt/build.sbt
+++ b/tests/fixtures/sbt/build.sbt
@@ -1,0 +1,5 @@
+enablePlugins(GatlingPlugin)
+
+scalaVersion := "2.13.16"
+
+libraryDependencies += "io.gatling.highcharts" % "gatling-charts-highcharts" % "3.13.5" % "test"

--- a/tests/fixtures/sbt/build.sbt
+++ b/tests/fixtures/sbt/build.sbt
@@ -1,5 +1,5 @@
 enablePlugins(GatlingPlugin)
 
-scalaVersion := "2.13.16"
+scalaVersion := "2.13.18"
 
 libraryDependencies += "io.gatling.highcharts" % "gatling-charts-highcharts" % "3.13.5" % "test"

--- a/tests/fixtures/sbt/project/plugins.sbt
+++ b/tests/fixtures/sbt/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.gatling" % "gatling-sbt" % "4.18.1")

--- a/tests/fixtures/sbt/src/test/scala/computerdatabase/BasicSimulation.scala
+++ b/tests/fixtures/sbt/src/test/scala/computerdatabase/BasicSimulation.scala
@@ -1,0 +1,25 @@
+package computerdatabase
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+import scala.concurrent.duration._
+
+class BasicSimulation extends Simulation {
+
+  val httpProtocol = http
+    .baseUrl("https://computer-database.gatling.io")
+    .acceptHeader("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+
+  val scn = scenario("BasicSimulation")
+    .exec(
+      http("home")
+        .get("/")
+        .check(status.is(200))
+    )
+
+  setUp(
+    scn.inject(atOnceUsers(1))
+  ).protocols(httpProtocol)
+    .maxDuration(30.seconds)
+}


### PR DESCRIPTION
## Summary

- Adds minimal `BasicSimulation` fixtures for all three build tools (sbt, maven, gradle) under `tests/fixtures/`
- Adds a `test-gatling-smoke` CI job that runs after `build-gatling-chain`, executing the real simulation against the freshly pushed runtime image for each matrix variant (sbt/maven/gradle × java 17/21)
- Adds missing `build.gradle` and `settings.gradle` for the gradle fixture
- Job fails on non-zero exit, catching broken entrypoints, missing plugins, or warmup cache corruption

## Changes

- `tests/fixtures/sbt/`: minimal sbt+gatling project with BasicSimulation
- `tests/fixtures/maven/`: minimal maven+gatling project with BasicSimulation
- `tests/fixtures/gradle/`: minimal gradle+gatling project with BasicSimulation (including new `build.gradle` and `settings.gradle`)
- `.github/workflows/build.yml`: new `test-gatling-smoke` job (6 matrix variants, post-build)

## Testing

Simulation runs `atOnceUsers(1)` against `computer-database.gatling.io`, designed to complete in < 30s. CI job exits non-zero on simulation failure.

Fixes galax-io/docker-images#32