### PR TITLE
test: add end-to-end integration tests that run actual built images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -259,9 +259,10 @@ jobs:
 
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             image_tags="${java_version}-${release_version}"$'\n'"${java_version}-${release_tag}"
+            base_version="${release_version}"
           else
-            image_tags="${java_version}"
-            base_version="latest"
+            image_tags="${java_version}"$'\n'"${java_version}-${{ github.sha }}"
+            base_version="${{ github.sha }}"
           fi
 
           case "${tool}" in
@@ -319,7 +320,7 @@ jobs:
             image_tags="${java_version}-${release_version}"$'\n'"${java_version}-${release_tag}"
           else
             builder_version="${java_version}"
-            image_tags="${java_version}"
+            image_tags="${java_version}"$'\n'"${java_version}-${{ github.sha }}"
           fi
 
           build_args=$'BUILDER_IMAGE='"${builder_image}"$'\nBUILDER_VERSION='"${builder_version}"$'\nBUILDER_TOOL='"${tool}"
@@ -367,7 +368,7 @@ jobs:
             image_tags="${java_version}-${release_version}"$'\n'"${java_version}-${release_tag}"
           else
             runtime_version="${java_version}"
-            image_tags="${java_version}"
+            image_tags="${java_version}"$'\n'"${java_version}-${{ github.sha }}"
           fi
 
           build_args=$'RUNTIME_IMAGE='"${runtime_image}"$'\nRUNTIME_VERSION='"${runtime_version}"
@@ -393,68 +394,6 @@ jobs:
           BUILD_ARGS: ${{ steps.debug-meta.outputs.build_args }}
           CONTEXT_DIR: ${{ env.BUILD_CONTEXT }}
         run: ./.github/scripts/buildkit-build.sh
-
-  integration-tests:
-    name: Integration tests — ${{ matrix.image_type }} (java ${{ matrix.java-version }})
-    runs-on: ubuntu-24.04
-    needs:
-      - prepare-release
-      - build-jdk
-      - build-gatling-chain
-    if: github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/')
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        java-version: ['17', '21']
-        image_type: ['jdk', 'sbt-builder', 'maven-builder', 'gradle-builder', 'sbt-runtime', 'maven-runtime', 'gradle-runtime']
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v5
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Resolve image reference
-        id: image
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          java_version="${{ matrix.java-version }}"
-          image_type="${{ matrix.image_type }}"
-
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            tag="${java_version}-${{ needs.prepare-release.outputs.release_version }}"
-          else
-            tag="${java_version}-${{ github.sha }}"
-          fi
-
-          case "${image_type}" in
-            jdk)
-              image_ref="galaxioteam/base-jdk:${tag}"
-              ;;
-            sbt-builder | maven-builder | gradle-builder)
-              tool="${image_type%-builder}"
-              image_ref="galaxioteam/gatling-${tool}-builder:${tag}"
-              ;;
-            sbt-runtime | maven-runtime | gradle-runtime)
-              tool="${image_type%-runtime}"
-              image_ref="galaxioteam/gatling-${tool}-runtime:${tag}"
-              ;;
-          esac
-
-          echo "image_ref=${image_ref}" >> "${GITHUB_OUTPUT}"
-
-      - name: Run integration tests
-        env:
-          IMAGE_REF: ${{ steps.image.outputs.image_ref }}
-          IMAGE_TYPE: ${{ matrix.image_type }}
-        run: bash tests/test_integration.sh
 
   changelog:
     name: Generate Changelog

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,11 +174,15 @@ jobs:
 
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             image_tags="${{ matrix.java-version }}-${release_version}"$'\n'"${{ matrix.java-version }}-${release_tag}"
+            base_version="${release_version}"
           else
-            image_tags="${{ matrix.java-version }}"
+            # Push both the mutable :<java> tag and an immutable :<java>-<sha> tag so that
+            # downstream jobs referencing base-jdk:<java>-<sha> can resolve the image.
+            image_tags="${{ matrix.java-version }}"$'\n'"${{ matrix.java-version }}-${{ github.sha }}"
+            base_version="${{ github.sha }}"
           fi
 
-          build_args=$'BASE_VERSION=latest\nJAVA_VERSION=${{ matrix.java-version }}'
+          build_args=$'BASE_VERSION='"${base_version}"$'\nJAVA_VERSION=${{ matrix.java-version }}'
 
           {
             echo "image_name=${image_name}"
@@ -390,6 +394,68 @@ jobs:
           CONTEXT_DIR: ${{ env.BUILD_CONTEXT }}
         run: ./.github/scripts/buildkit-build.sh
 
+  integration-tests:
+    name: Integration tests — ${{ matrix.image_type }} (java ${{ matrix.java-version }})
+    runs-on: ubuntu-24.04
+    needs:
+      - prepare-release
+      - build-jdk
+      - build-gatling-chain
+    if: github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: ['17', '21']
+        image_type: ['jdk', 'sbt-builder', 'maven-builder', 'gradle-builder', 'sbt-runtime', 'maven-runtime', 'gradle-runtime']
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v5
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Resolve image reference
+        id: image
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          java_version="${{ matrix.java-version }}"
+          image_type="${{ matrix.image_type }}"
+
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            tag="${java_version}-${{ needs.prepare-release.outputs.release_version }}"
+          else
+            tag="${java_version}-${{ github.sha }}"
+          fi
+
+          case "${image_type}" in
+            jdk)
+              image_ref="galaxioteam/base-jdk:${tag}"
+              ;;
+            sbt-builder | maven-builder | gradle-builder)
+              tool="${image_type%-builder}"
+              image_ref="galaxioteam/gatling-${tool}-builder:${tag}"
+              ;;
+            sbt-runtime | maven-runtime | gradle-runtime)
+              tool="${image_type%-runtime}"
+              image_ref="galaxioteam/gatling-${tool}-runtime:${tag}"
+              ;;
+          esac
+
+          echo "image_ref=${image_ref}" >> "${GITHUB_OUTPUT}"
+
+      - name: Run integration tests
+        env:
+          IMAGE_REF: ${{ steps.image.outputs.image_ref }}
+          IMAGE_TYPE: ${{ matrix.image_type }}
+        run: bash tests/test_integration.sh
+
   changelog:
     name: Generate Changelog
     runs-on: ubuntu-24.04
@@ -418,6 +484,7 @@ jobs:
       - prepare-release
       - build-jdk
       - build-gatling-chain
+      - integration-tests
     if: github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
@@ -465,6 +532,7 @@ jobs:
       - prepare-release
       - build-jdk
       - build-gatling-chain
+      - integration-tests
       - changelog
     permissions:
       contents: write

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -63,8 +63,9 @@ jobs:
           dockerfile_path="java.Dockerfile"
           cache_ref="${CACHE_REPOSITORY}:base-jdk-${{ matrix.java-version }}-pr"
           image_tags="${{ matrix.java-version }}-${sha_tag}"
-          # Base image (galaxioteam/galaxio) is external — built in galax-io/galaxio-cli repo
-          build_args=$'BASE_VERSION=latest\nJAVA_VERSION=${{ matrix.java-version }}'
+          # BASE_VERSION is defined but not consumed by java.Dockerfile (base-jdk builds directly from
+          # eclipse-temurin, not from another base-jdk image). Passed here for Dockerfile ARG parity only.
+          build_args=$'BASE_VERSION='"${sha_tag}"$'\nJAVA_VERSION=${{ matrix.java-version }}'
 
           {
             echo "image_name=${image_name}"

--- a/tests/test_integration.sh
+++ b/tests/test_integration.sh
@@ -55,7 +55,7 @@ printf '=== Integration test: %s  (type=%s) ===\n\n' "${IMAGE_REF}" "${IMAGE_TYP
 # Test 1: pull image
 # ---------------------------------------------------------------------------
 printf '--- Test: docker pull ---\n'
-check "docker pull ${IMAGE_REF}" docker pull "${IMAGE_REF}"
+check "docker pull ${IMAGE_REF}" timeout 120 docker pull "${IMAGE_REF}"
 
 # ---------------------------------------------------------------------------
 # Test 2: non-root UID = 65532
@@ -65,9 +65,9 @@ check "docker pull ${IMAGE_REF}" docker pull "${IMAGE_REF}"
 printf '--- Test: non-root UID ---\n'
 case "${IMAGE_TYPE}" in
   *-runtime)
-    uid_output="$(docker run --rm "${IMAGE_REF}" "id -u" 2>&1 || echo "error")" ;;
+    uid_output="$(timeout 60 docker run --rm "${IMAGE_REF}" "id -u" 2>&1 || echo "error")" ;;
   *)
-    uid_output="$(docker run --rm "${IMAGE_REF}" id -u 2>&1 || echo "error")" ;;
+    uid_output="$(timeout 60 docker run --rm "${IMAGE_REF}" id -u 2>&1 || echo "error")" ;;
 esac
 uid_output="$(printf '%s' "${uid_output}" | tr -d '[:space:]')"
 if [[ "${uid_output}" == "65532" ]]; then
@@ -82,9 +82,9 @@ fi
 printf '--- Test: entrypoint ---\n'
 case "${IMAGE_TYPE}" in
   *-runtime)
-    check "entrypoint echo ok" docker run --rm "${IMAGE_REF}" "echo ok" ;;
+    check "entrypoint echo ok" timeout 60 docker run --rm "${IMAGE_REF}" "echo ok" ;;
   *)
-    check "entrypoint echo ok" docker run --rm "${IMAGE_REF}" echo ok ;;
+    check "entrypoint echo ok" timeout 60 docker run --rm "${IMAGE_REF}" echo ok ;;
 esac
 
 # ---------------------------------------------------------------------------
@@ -93,13 +93,13 @@ esac
 printf '--- Test: build tool ---\n'
 case "${IMAGE_TYPE}" in
   *sbt*)
-    check "sbt --version" docker run --rm "${IMAGE_REF}" sbt --version ;;
+    check "sbt --version" timeout 60 docker run --rm "${IMAGE_REF}" sbt --version ;;
   *maven*)
-    check "mvn --version" docker run --rm "${IMAGE_REF}" mvn --version ;;
+    check "mvn --version" timeout 60 docker run --rm "${IMAGE_REF}" mvn --version ;;
   *gradle*)
-    check "gradle --version" docker run --rm "${IMAGE_REF}" gradle --version ;;
+    check "gradle --version" timeout 60 docker run --rm "${IMAGE_REF}" gradle --version ;;
   *)
-    check "java -version" docker run --rm "${IMAGE_REF}" java -version ;;
+    check "java -version" timeout 60 docker run --rm "${IMAGE_REF}" java -version ;;
 esac
 
 # ---------------------------------------------------------------------------

--- a/tests/test_integration.sh
+++ b/tests/test_integration.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Integration tests for Galaxio Docker images.
+# Pulls the specified image and asserts:
+#   1. The image can be pulled
+#   2. The container runs as UID 65532 (nonroot)
+#   3. The entrypoint works (docker run echo ok)
+#   4. The relevant build tool responds (java/sbt/mvn/gradle --version)
+#
+# Usage (positional):
+#   bash tests/test_integration.sh <IMAGE_REF> [IMAGE_TYPE]
+#
+# Usage (env vars):
+#   IMAGE_REF=galaxioteam/base-jdk:21-abc1234 IMAGE_TYPE=jdk bash tests/test_integration.sh
+#
+# IMAGE_TYPE values: jdk | sbt-builder | maven-builder | gradle-builder |
+#                    sbt-runtime | maven-runtime | gradle-runtime
+#
+# Exit codes: 0 = all assertions passed, non-zero = one or more failures.
+
+set -uo pipefail
+
+IMAGE_REF="${1:-${IMAGE_REF:-}}"
+IMAGE_TYPE="${2:-${IMAGE_TYPE:-jdk}}"
+
+if [[ -z "${IMAGE_REF}" ]]; then
+  printf 'ERROR: IMAGE_REF (or $1) is required — full image:tag to test\n' >&2
+  exit 1
+fi
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+  PASS_COUNT=$((PASS_COUNT + 1))
+  printf 'PASS: %s\n' "$1"
+}
+
+fail() {
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  printf 'FAIL: %s\n' "$1" >&2
+}
+
+check() {
+  local desc="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    pass "${desc}"
+  else
+    fail "${desc}"
+  fi
+}
+
+printf '=== Integration test: %s  (type=%s) ===\n\n' "${IMAGE_REF}" "${IMAGE_TYPE}"
+
+# ---------------------------------------------------------------------------
+# Test 1: pull image
+# ---------------------------------------------------------------------------
+printf '--- Test: docker pull ---\n'
+check "docker pull ${IMAGE_REF}" docker pull "${IMAGE_REF}"
+
+# ---------------------------------------------------------------------------
+# Test 2: non-root UID = 65532
+# Runtime images use ENTRYPOINT ["/bin/bash", "-c"], pass command as string.
+# Other images have no custom ENTRYPOINT — pass command directly.
+# ---------------------------------------------------------------------------
+printf '--- Test: non-root UID ---\n'
+case "${IMAGE_TYPE}" in
+  *-runtime)
+    uid_output="$(docker run --rm "${IMAGE_REF}" "id -u" 2>&1 || echo "error")" ;;
+  *)
+    uid_output="$(docker run --rm "${IMAGE_REF}" id -u 2>&1 || echo "error")" ;;
+esac
+uid_output="$(printf '%s' "${uid_output}" | tr -d '[:space:]')"
+if [[ "${uid_output}" == "65532" ]]; then
+  pass "UID is 65532 (nonroot)"
+else
+  fail "UID is '${uid_output}', expected 65532"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: entrypoint echo
+# ---------------------------------------------------------------------------
+printf '--- Test: entrypoint ---\n'
+case "${IMAGE_TYPE}" in
+  *-runtime)
+    check "entrypoint echo ok" docker run --rm "${IMAGE_REF}" "echo ok" ;;
+  *)
+    check "entrypoint echo ok" docker run --rm "${IMAGE_REF}" echo ok ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Test 4: build tool version check
+# ---------------------------------------------------------------------------
+printf '--- Test: build tool ---\n'
+case "${IMAGE_TYPE}" in
+  *sbt*)
+    check "sbt --version" docker run --rm "${IMAGE_REF}" sbt --version ;;
+  *maven*)
+    check "mvn --version" docker run --rm "${IMAGE_REF}" mvn --version ;;
+  *gradle*)
+    check "gradle --version" docker run --rm "${IMAGE_REF}" gradle --version ;;
+  *)
+    check "java -version" docker run --rm "${IMAGE_REF}" java -version ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n=== Results: %d passed, %d failed ===\n' "${PASS_COUNT}" "${FAIL_COUNT}"
+
+[ "${FAIL_COUNT}" -eq 0 ]


### PR DESCRIPTION
## Summary

Adds `tests/test_integration.sh` with pull verification, non-root UID assertion, entrypoint smoke test, and build-tool version checks against the actual built images. Hooks into CI as a separate post-push job, keeping existing unit/mock tests intact.

## Changes

- `tests/test_integration.sh`: new integration test script (pull + run assertions)
- `.github/workflows/build.yml`: new `integration-tests` job gated on image push

## Testing

Tests cover: non-root UID (65532), entrypoint resolves, build tool version responds. All 7 image types covered: jdk, sbt-builder, maven-builder, gradle-builder, sbt-runtime, maven-runtime, gradle-runtime. Existing unit tests unchanged.

Fixes galax-io/docker-images#33